### PR TITLE
Fix scout #1863

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## x.x.x
+###
+- POST gene_ids in genes list navigation
+
 ## 3.2.0 (2019-02-25)
 ### Added
 POST gene_ids in genes view

--- a/chanjo_report/server/blueprints/report/templates/report/gene.html
+++ b/chanjo_report/server/blueprints/report/templates/report/gene.html
@@ -66,7 +66,7 @@
 													{% else %}
 														{{ exon.chrom }}:{{ exon.start }}-{{ exon.end }}
 													{% endif %}
-													<span class="pull-right">
+													<span class="float-right">
 														<strong>{{ exon.completeness|round(2) }}%</strong>
 													</span>
 												</td>

--- a/chanjo_report/server/blueprints/report/templates/report/genes.html
+++ b/chanjo_report/server/blueprints/report/templates/report/genes.html
@@ -81,13 +81,19 @@
 		<div class="col-md-6">
 			{% if skip > 0 %}
 				{% set next_skip = 0 if (skip - limit) < 0 else (skip - limit) %}
-				<a href="{{ url_for('report.genes', level=level, skip=next_skip, limit=limit, gene_id=gene_ids|join(','), sample_id=sample_ids) }}" class="btn btn-default">Previous</a>
+				<form id="report-genes-previous" method="POST" action="{{ url_for('report.genes', level=level, skip=next_skip, limit=limit, sample_id=sample_ids) }}">
+					<input type="hidden" name="gene_id" value="{{ gene_ids|join(',') }}">
+					<button type="submit" class="btn btn-default">Previous</button>
+				</form>
 			{% endif %}
 		</div>
 		<div class="col-md-6">
 			{% if has_next %}
-				<div class="pull-right">
-					<a href="{{ url_for('report.genes', level=level, skip=(skip + limit), limit=limit, gene_id=gene_ids|join(','), sample_id=sample_ids) }}" class="btn btn-default">Next</a>
+				<div class="float-right">
+					<form id="report-genes-next" method="POST" action="{{ url_for('report.genes', level=level, skip=(skip + limit), limit=limit, sample_id=sample_ids) }}">
+						<input type="hidden" name="gene_id" value="{{ gene_ids|join(',') }}">
+						<button type="submit" class="btn btn-default">Next</button>
+					</form>
 				</div>
 			{% endif %}
 		</div>

--- a/chanjo_report/server/blueprints/report/templates/report/genes.html
+++ b/chanjo_report/server/blueprints/report/templates/report/genes.html
@@ -89,7 +89,7 @@
 		</div>
 		<div class="col-md-6">
 			{% if has_next %}
-				<div class="pull-right">
+				<div class="float-right">
 					<form id="report-genes-next" method="POST" action="{{ url_for('report.genes', level=level, skip=(skip + limit), limit=limit, sample_id=sample_ids) }}">
 						<input type="hidden" name="gene_id" value="{{ gene_ids|join(',') }}">
 						<button type="submit" class="btn btn-default">Next</button>

--- a/chanjo_report/server/blueprints/report/templates/report/genes.html
+++ b/chanjo_report/server/blueprints/report/templates/report/genes.html
@@ -89,7 +89,7 @@
 		</div>
 		<div class="col-md-6">
 			{% if has_next %}
-				<div class="float-right">
+				<div class="pull-right">
 					<form id="report-genes-next" method="POST" action="{{ url_for('report.genes', level=level, skip=(skip + limit), limit=limit, sample_id=sample_ids) }}">
 						<input type="hidden" name="gene_id" value="{{ gene_ids|join(',') }}">
 						<button type="submit" class="btn btn-default">Next</button>

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ with codecs.open(os.path.join(HERE, 'README.md'), encoding='utf-8') as f:
 
 setup(name='chanjo-report',
       # versions should comply with PEP440
-      version='4.3.0',
+      version='4.4.0',
       description='Automatically render coverage reports from Chanjo ouput',
       long_description=LONG_DESCRIPTION,
       # what does your project relate to?


### PR DESCRIPTION
See https://github.com/Clinical-Genomics/scout/issues/1863; basically a next / previous navigation button pair that is using GET instead of POST and crashing on long gene id lists.