### PR TITLE
Fix gene list parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change log
 
+## 4.4.1 (2020-04-27)
+### Fixed
+- return error message when users provide a non-numerical list of gene IDs
 
 ## 4.4.0 (2020-04-23)
 ### Added

--- a/chanjo_report/server/blueprints/report/views.py
+++ b/chanjo_report/server/blueprints/report/views.py
@@ -80,7 +80,7 @@ def report():
         # gene ids should be numerical, if they are strings print error String instead
         gene_ids = [int(gene_id) for gene_id in gene_ids]
     except ValueError:
-        return "Gene format not supported. Gene lists should contain comma-separated HGNC numerical identifiers, not strings."
+        return "Gene format not supported. Gene list should contain comma-separated HGNC numerical identifiers, not strings."
 
     level = int(request.args.get('level') or request.form.get('level') or 10)
     extras = {

--- a/chanjo_report/server/blueprints/report/views.py
+++ b/chanjo_report/server/blueprints/report/views.py
@@ -69,14 +69,19 @@ def report():
     """Generate a coverage report for a group of samples."""
     sample_ids = request.args.getlist('sample_id') or request.form.getlist('sample_id')
     raw_gene_ids = (request.args.get('gene_ids') or request.form.get('gene_ids'))
+    gene_ids = []
     if raw_gene_ids:
         session['all_genes'] = raw_gene_ids
-        gene_ids = [int(gene_id.strip()) for gene_id in raw_gene_ids.split(',')]
+        gene_ids = [gene_id.strip() for gene_id in raw_gene_ids.split(',')]
     else:
         if request.method=='GET' and session.get('all_genes'):
-            gene_ids = [int(gene_id.strip()) for gene_id in session.get('all_genes').split(',')]
-        else:
-            gene_ids = []
+            gene_ids = [gene_id.strip() for gene_id in session.get('all_genes').split(',')]
+    try:
+        # gene ids should be numerical, if they are strings print error String instead
+        gene_ids = [int(gene_id) for gene_id in gene_ids]
+    except ValueError:
+        return "Gene format not supported. Gene lists should contain comma-separated HGNC numerical identifiers, not strings."
+
     level = int(request.args.get('level') or request.form.get('level') or 10)
     extras = {
         'panel_name': (request.args.get('panel_name') or request.form.get('panel_name')),


### PR DESCRIPTION
This is not a classy fix to #5 . instead of crashing, the app should show a blank page with the message:

`Gene format not supported. Gene list should contain comma-separated HGNC numerical identifiers, not strings.`

Ugly but effective. I'm open to suggestions on how to improve this.

One way to prevent this error (but I still think chanjo-report requires a fix) is doing some check upstream, at the moment that scout users submit the gene list to create the coverage report