### PR TITLE
Endpoint to return coverage over a list of genes for one of more samples as json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log
 
+
+## 4.5 (2020-09-29)
+### Added
+- Endpoint that returns mean coverage over one or more genes for a list of samples, in json
+
 ## 4.4.1 (2020-04-27)
 ### Fixed
 - return error message when users provide a non-numerical list of gene IDs

--- a/chanjo_report/server/blueprints/report/views.py
+++ b/chanjo_report/server/blueprints/report/views.py
@@ -76,7 +76,8 @@ def json_genes():
     gene_ids = data.get('gene_ids').split(",")
 
     metrics_rows = keymetrics_rows(sample_ids, genes=gene_ids)
-    return json.dumps(metrics_rows.all())
+    return json.dumps([dict(stats) for stats in metrics_rows])
+
 
 @report_bp.route('/report', methods=['GET', 'POST'])
 def report():

--- a/chanjo_report/server/blueprints/report/views.py
+++ b/chanjo_report/server/blueprints/report/views.py
@@ -97,7 +97,7 @@ def report():
         # gene ids should be numerical, if they are strings print error String instead
         gene_ids = [int(gene_id) for gene_id in gene_ids]
     except ValueError:
-        return "Gene format not supported. Gene list should contain HGNC identifiers ()"
+        return "Gene format not supported. Gene list should contain comma-separated HGNC numerical identifiers, not strings."
 
     level = int(request.args.get('level') or request.form.get('level') or 10)
     extras = {

--- a/chanjo_report/server/blueprints/report/views.py
+++ b/chanjo_report/server/blueprints/report/views.py
@@ -78,7 +78,7 @@ def json_genes():
     query = query.filter(Transcript.gene_id.in_(gene_ids))
     # And sample ID
     query = query.filter(TranscriptStat.sample_id.in_(sample_ids))
-    return jsonify({'query':query.__dict__})
+    return str(query)
 
 
 @report_bp.route('/report', methods=['GET', 'POST'])

--- a/chanjo_report/server/blueprints/report/views.py
+++ b/chanjo_report/server/blueprints/report/views.py
@@ -70,8 +70,11 @@ def json_genes():
     #curl -d 'sample_ids=ADM1059A4,ADM1059A5,ADM1059A6' https://scout-stage.scilifelab.se/reports/json_genes
     # Collect sample IDs from user form
     sample_ids = request.form.get('sample_ids').split(",") if request.form.get('sample_ids') else []
+
     # Collect gene list from user form
     gene_ids = request.form.get('gene_ids').split(",") if request.form.get('gene_ids') else []
+
+    return f"sample_ids:{','.split(sample_ids)} -- gene_ids:{','.split(gene_ids)}"
 
     query = api.query(TranscriptStat).join(TranscriptStat.transcript)
     # Filter coverage data by gene ID

--- a/chanjo_report/server/blueprints/report/views.py
+++ b/chanjo_report/server/blueprints/report/views.py
@@ -2,7 +2,7 @@
 import logging
 import datetime
 from chanjo.store.models import Transcript, TranscriptStat, Sample
-from flask import abort, Blueprint, render_template, request, url_for, session
+from flask import abort, Blueprint, render_template, request, url_for, session, jsonify
 from flask_weasyprint import render_pdf
 
 from chanjo_report.server.extensions import api

--- a/chanjo_report/server/blueprints/report/views.py
+++ b/chanjo_report/server/blueprints/report/views.py
@@ -3,7 +3,6 @@ import logging
 import datetime
 
 from chanjo.store.models import Transcript, TranscriptStat, Sample
-from chanhio.calculate import sample_coverage
 from flask import abort, Blueprint, render_template, request, url_for, session, jsonify
 from flask_weasyprint import render_pdf
 
@@ -76,10 +75,8 @@ def json_genes():
     # Collect gene list from user form
     gene_ids = data.get('gene_ids').split(",")
 
-    query = api.sample_coverage(sample_ids=sample_ids, genes=gene_ids)
-    return str(query)
-
-
+    metrics_rows = keymetrics_rows(sample_ids, genes=gene_ids)
+    return str(metrics_rows)
 
 
 @report_bp.route('/report', methods=['GET', 'POST'])

--- a/chanjo_report/server/blueprints/report/views.py
+++ b/chanjo_report/server/blueprints/report/views.py
@@ -67,15 +67,15 @@ def genes():
 @report_bp.route('/json_genes', methods=['POST'])
 def json_genes():
     """Calculate mean coverage over all genes of a chromosome and return"""
-    #curl -d 'sample_ids=ADM1059A4,ADM1059A5,ADM1059A6' https://scout-stage.scilifelab.se/reports/json_genes
-    if request.form.get('gene_ids') is None or request.form.get('sample_ids') is None:
-        return {}
 
+    data = request.json
+    if data.get('gene_ids') is None or data.get('sample_ids') is None:
+        return
     # Collect sample IDs from user form
-    sample_ids = request.form.get('sample_ids').split(",")
+    sample_ids = data.get('sample_ids').split(",")
 
     # Collect gene list from user form
-    gene_ids = request.form.get('gene_ids').split(",")
+    gene_ids = data.split(",")
 
     query = api.query(TranscriptStat).join(TranscriptStat.transcript)
     # Filter coverage data by gene ID

--- a/chanjo_report/server/blueprints/report/views.py
+++ b/chanjo_report/server/blueprints/report/views.py
@@ -68,13 +68,14 @@ def genes():
 def json_genes():
     """Calculate mean coverage over all genes of a chromosome and return"""
     #curl -d 'sample_ids=ADM1059A4,ADM1059A5,ADM1059A6' https://scout-stage.scilifelab.se/reports/json_genes
+    if request.form.get('gene_ids') is None or request.form.get('sample_ids') is None:
+        return {}
+
     # Collect sample IDs from user form
-    sample_ids = request.form.get('sample_ids').split(",") if request.form.get('sample_ids') else []
+    sample_ids = request.form.get('sample_ids').split(",")
 
     # Collect gene list from user form
-    gene_ids = request.form.get('gene_ids').split(",") if request.form.get('gene_ids') else []
-
-    return f"sample_ids:{str(sample_ids)} -- gene_ids:{str(gene_ids)}"
+    gene_ids = request.form.get('gene_ids').split(",")
 
     query = api.query(TranscriptStat).join(TranscriptStat.transcript)
     # Filter coverage data by gene ID

--- a/chanjo_report/server/blueprints/report/views.py
+++ b/chanjo_report/server/blueprints/report/views.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 import logging
 import datetime
-
+import json
 from chanjo.store.models import Transcript, TranscriptStat, Sample
-from flask import abort, Blueprint, render_template, request, url_for, session, jsonify
+from flask import abort, Blueprint, render_template, request, url_for, session
 from flask_weasyprint import render_pdf
 
 from chanjo_report.server.extensions import api
@@ -76,8 +76,7 @@ def json_genes():
     gene_ids = data.get('gene_ids').split(",")
 
     metrics_rows = keymetrics_rows(sample_ids, genes=gene_ids)
-    return jsonify(result_list = metrics_rows.all())
-
+    return json.dumps(metrics_rows.all().__dict__)
 
 @report_bp.route('/report', methods=['GET', 'POST'])
 def report():

--- a/chanjo_report/server/blueprints/report/views.py
+++ b/chanjo_report/server/blueprints/report/views.py
@@ -76,7 +76,7 @@ def json_genes():
     gene_ids = data.get('gene_ids').split(",")
 
     metrics_rows = keymetrics_rows(sample_ids, genes=gene_ids)
-    return str(metrics_rows)
+    return jsonify(result_list = metrics_rows.all())
 
 
 @report_bp.route('/report', methods=['GET', 'POST'])

--- a/chanjo_report/server/blueprints/report/views.py
+++ b/chanjo_report/server/blueprints/report/views.py
@@ -67,22 +67,24 @@ def genes():
 @report_bp.route('/json_genes', methods=['POST'])
 def json_genes():
     """Calculate mean coverage over all genes of a chromosome and return"""
-
     data = request.json
     if data.get('gene_ids') is None or data.get('sample_ids') is None:
         return
     # Collect sample IDs from user form
     sample_ids = data.get('sample_ids').split(",")
-
     # Collect gene list from user form
     gene_ids = data.get('gene_ids').split(",")
 
     query = api.query(TranscriptStat).join(TranscriptStat.transcript)
-    # Filter coverage data by gene ID
+    # Filter coverage data by gene IDs
     query = query.filter(Transcript.gene_id.in_(gene_ids))
-    # And sample ID
+    # And sample IDs
     query = query.filter(TranscriptStat.sample_id.in_(sample_ids))
-    return str(query)
+
+    return jsonify({"stats":query.stats})
+
+
+
 
 
 @report_bp.route('/report', methods=['GET', 'POST'])

--- a/chanjo_report/server/blueprints/report/views.py
+++ b/chanjo_report/server/blueprints/report/views.py
@@ -69,17 +69,12 @@ def json_genes():
     data = request.json
     if data.get('gene_ids') is None or data.get('sample_ids') is None:
         return
-    # Collect sample IDs from user form
-    sample_ids = data.get('sample_ids').split(",")
-    # Collect gene list from user form
-    gene_ids = data.get('gene_ids').split(",")
-    metrics_rows = keymetrics_rows(sample_ids, genes=gene_ids).all()
 
+    metrics_rows = keymetrics_rows(sample_ids, genes=gene_ids).all()
     results = {}
     for row in metrics_rows:
         ts = row[0] # An object of class TranscriptStat
-        results[ts.sample_id] = ts.mean_coverage
-
+        results[ts.sample_id] = ts.mean_coverage # Collect mean coverage over the genes
     return jsonify(results)
 
 

--- a/chanjo_report/server/blueprints/report/views.py
+++ b/chanjo_report/server/blueprints/report/views.py
@@ -78,7 +78,7 @@ def json_genes():
     query = query.filter(Transcript.gene_id.in_(gene_ids))
     # And sample ID
     query = query.filter(TranscriptStat.sample_id.in_(sample_ids))
-    return jsonify({'query':})
+    return jsonify({'query':query})
 
 
 @report_bp.route('/report', methods=['GET', 'POST'])

--- a/chanjo_report/server/blueprints/report/views.py
+++ b/chanjo_report/server/blueprints/report/views.py
@@ -63,8 +63,8 @@ def genes():
                            sample_ids=sample_ids)
 
 
-@report_bp.route('/json_genes', methods=['POST'])
-def json_genes():
+@report_bp.route('/json_gene_coverage', methods=['POST'])
+def json_gene_coverage():
     """Calculate mean coverage over a list of genes for one or more samples and return results as json"""
     data = request.json
     if data.get('gene_ids') is None or data.get('sample_ids') is None:

--- a/chanjo_report/server/blueprints/report/views.py
+++ b/chanjo_report/server/blueprints/report/views.py
@@ -74,7 +74,7 @@ def json_genes():
     # Collect gene list from user form
     gene_ids = request.form.get('gene_ids').split(",") if request.form.get('gene_ids') else []
 
-    return f"sample_ids:{','.split(sample_ids)} -- gene_ids:{','.split(gene_ids)}"
+    return f"sample_ids:{str(sample_ids)} -- gene_ids:{str(gene_ids)}"
 
     query = api.query(TranscriptStat).join(TranscriptStat.transcript)
     # Filter coverage data by gene ID

--- a/chanjo_report/server/blueprints/report/views.py
+++ b/chanjo_report/server/blueprints/report/views.py
@@ -76,7 +76,7 @@ def json_genes():
     gene_ids = data.get('gene_ids').split(",")
 
     metrics_rows = keymetrics_rows(sample_ids, genes=gene_ids)
-    return json.dumps(metrics_rows.all().__dict__)
+    return json.dumps(metrics_rows.all())
 
 @report_bp.route('/report', methods=['GET', 'POST'])
 def report():

--- a/chanjo_report/server/blueprints/report/views.py
+++ b/chanjo_report/server/blueprints/report/views.py
@@ -65,7 +65,7 @@ def genes():
 
 @report_bp.route('/json_genes', methods=['POST'])
 def json_genes():
-    """Calculate mean coverage over all genes of a chromosome and return"""
+    """Calculate mean coverage over a list of genes for one or more samples and return results as json"""
     data = request.json
     if data.get('gene_ids') is None or data.get('sample_ids') is None:
         return

--- a/chanjo_report/server/blueprints/report/views.py
+++ b/chanjo_report/server/blueprints/report/views.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import logging
 import datetime
-import json
 from chanjo.store.models import Transcript, TranscriptStat, Sample
 from flask import abort, Blueprint, render_template, request, url_for, session
 from flask_weasyprint import render_pdf
@@ -74,10 +73,14 @@ def json_genes():
     sample_ids = data.get('sample_ids').split(",")
     # Collect gene list from user form
     gene_ids = data.get('gene_ids').split(",")
+    metrics_rows = keymetrics_rows(sample_ids, genes=gene_ids).all()
 
-    metrics_rows = keymetrics_rows(sample_ids, genes=gene_ids)
+    results = {}
+    for row in metrics_rows:
+        ts = TranscriptStat(row[0])
+        results[ts.sample_id] = ts.mean_coverage
 
-    return str(metrics_rows.all())
+    return jsonify(results)
 
 
 @report_bp.route('/report', methods=['GET', 'POST'])

--- a/chanjo_report/server/blueprints/report/views.py
+++ b/chanjo_report/server/blueprints/report/views.py
@@ -66,15 +66,17 @@ def genes():
 @report_bp.route('/json_gene_coverage', methods=['POST'])
 def json_gene_coverage():
     """Calculate mean coverage over a list of genes for one or more samples and return results as json"""
+    results = {}
     data = request.json
+
     if data.get('gene_ids') is None or data.get('sample_ids') is None:
-        return
+        return jsonify(results)
 
     gene_ids = data.get('gene_ids').split(",")
     sample_ids = data.get('sample_ids').split(",")
 
     metrics_rows = keymetrics_rows(sample_ids, genes=gene_ids).all()
-    results = {}
+
     for row in metrics_rows:
         ts = row[0] # An object of class TranscriptStat
         results[ts.sample_id] = ts.mean_coverage # Collect mean coverage over the genes

--- a/chanjo_report/server/blueprints/report/views.py
+++ b/chanjo_report/server/blueprints/report/views.py
@@ -81,7 +81,7 @@ def json_genes():
     # And sample IDs
     query = query.filter(TranscriptStat.sample_id.in_(sample_ids))
 
-    return jsonify({"stats":query.stats})
+    return str(query.all)
 
 
 

--- a/chanjo_report/server/blueprints/report/views.py
+++ b/chanjo_report/server/blueprints/report/views.py
@@ -70,6 +70,9 @@ def json_gene_coverage():
     if data.get('gene_ids') is None or data.get('sample_ids') is None:
         return
 
+    gene_ids = data.get('gene_ids').split(",")
+    sample_ids = data.get('sample_ids').split(",")
+
     metrics_rows = keymetrics_rows(sample_ids, genes=gene_ids).all()
     results = {}
     for row in metrics_rows:

--- a/chanjo_report/server/blueprints/report/views.py
+++ b/chanjo_report/server/blueprints/report/views.py
@@ -76,7 +76,7 @@ def json_genes():
     gene_ids = data.get('gene_ids').split(",")
 
     metrics_rows = keymetrics_rows(sample_ids, genes=gene_ids)
-    return json.dumps([dict(stats) for stats in metrics_rows])
+    return json.dumps([ row.__dict__ for row in metrics_rows ])
 
 
 @report_bp.route('/report', methods=['GET', 'POST'])

--- a/chanjo_report/server/blueprints/report/views.py
+++ b/chanjo_report/server/blueprints/report/views.py
@@ -78,7 +78,7 @@ def json_genes():
     query = query.filter(Transcript.gene_id.in_(gene_ids))
     # And sample ID
     query = query.filter(TranscriptStat.sample_id.in_(sample_ids))
-    return jsonify({'query':query})
+    return jsonify({'query':query.__dict__})
 
 
 @report_bp.route('/report', methods=['GET', 'POST'])

--- a/chanjo_report/server/blueprints/report/views.py
+++ b/chanjo_report/server/blueprints/report/views.py
@@ -77,7 +77,7 @@ def json_genes():
 
     results = {}
     for row in metrics_rows:
-        ts = TranscriptStat(row[0])
+        ts = row[0] # An object of class TranscriptStat
         results[ts.sample_id] = ts.mean_coverage
 
     return jsonify(results)

--- a/chanjo_report/server/blueprints/report/views.py
+++ b/chanjo_report/server/blueprints/report/views.py
@@ -76,7 +76,8 @@ def json_genes():
     gene_ids = data.get('gene_ids').split(",")
 
     metrics_rows = keymetrics_rows(sample_ids, genes=gene_ids)
-    return json.dumps([ row.__dict__ for row in metrics_rows ])
+
+    return str(metrics_rows.all())
 
 
 @report_bp.route('/report', methods=['GET', 'POST'])

--- a/chanjo_report/server/blueprints/report/views.py
+++ b/chanjo_report/server/blueprints/report/views.py
@@ -3,6 +3,7 @@ import logging
 import datetime
 
 from chanjo.store.models import Transcript, TranscriptStat, Sample
+from chanhio.calculate import sample_coverage
 from flask import abort, Blueprint, render_template, request, url_for, session, jsonify
 from flask_weasyprint import render_pdf
 
@@ -75,14 +76,8 @@ def json_genes():
     # Collect gene list from user form
     gene_ids = data.get('gene_ids').split(",")
 
-    query = api.query(TranscriptStat).join(TranscriptStat.transcript)
-    # Filter coverage data by gene IDs
-    query = query.filter(Transcript.gene_id.in_(gene_ids))
-    # And sample IDs
-    query = query.filter(TranscriptStat.sample_id.in_(sample_ids))
-
-    return str(query.all)
-
+    query = api.sample_coverage(sample_ids=sample_ids, genes=gene_ids)
+    return str(query)
 
 
 

--- a/chanjo_report/server/blueprints/report/views.py
+++ b/chanjo_report/server/blueprints/report/views.py
@@ -75,7 +75,7 @@ def json_genes():
     sample_ids = data.get('sample_ids').split(",")
 
     # Collect gene list from user form
-    gene_ids = data.split(",")
+    gene_ids = data.get('gene_ids').split(",")
 
     query = api.query(TranscriptStat).join(TranscriptStat.transcript)
     # Filter coverage data by gene ID

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,3 @@ tabulate
 toml
 toolz
 pymysql
-json

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ tabulate
 toml
 toolz
 pymysql
+json


### PR DESCRIPTION
### This PR adds 
- Return mean coverage over a list of genes for one or more samples, as a json object.

**How to prepare for test**:
- [x] as user hiseq.clinical, install the branch on clinical-db stage, install the branch `mt_vs_automosome_coverage` of scout: 
```
cd home/hiseq.clinical/servers/resources/clinical-db.scilifelab.se
bash update-scout-stage.sh mt_vs_automosome_coverage
```
- [x] Then install this chanjo-report branch on clinical-db stage:
```
bash update-chanjo-report-stage.sh json_coverage
```
### How to test:
- From a terminal, send a POST request to the endpoint using curl. Example:

```
curl -i -H "Content-Type: application/json" -X POST \
-d '{"sample_ids":"ADM1059A4,ADM1059A5,ADM1059A6", "gene_ids": "17284,2577,8582,2950"}' \
https://scout-stage.scilifelab.se/reports/json_gene_coverage
```

### Expected outcome:
- Something like this: 
`{"ADM1059A4":28.4929,"ADM1059A5":31.0761,"ADM1059A6":28.5271}`

### Review:
- [x] Code approved by MM
- [x] Tests executed by CR
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
