### PR TITLE
Chrom coverage as json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log
 
+## 4.6 (2020-09-30)
+### Added
+- Endpoint that returns mean coverage over all transcripts of a cromsosome for a list of samples, in json
+### Fixed
+- Value returned by the endpoint collecting mean coverage over genes, returning json objects
 
 ## 4.5 (2020-09-29)
 ### Added

--- a/chanjo_report/server/blueprints/report/utils.py
+++ b/chanjo_report/server/blueprints/report/utils.py
@@ -13,7 +13,7 @@ from chanjo_report.server.extensions import api
 
 LOG = logging.getLogger(__name__)
 
-def chromosome_coverage(chrom, *sample_ids):
+def chromosome_coverage(chrom, *samples_ids):
     """Return mean coverage over all transcripts of a chromosome for one or more samples"""
 
     query = (

--- a/chanjo_report/server/blueprints/report/utils.py
+++ b/chanjo_report/server/blueprints/report/utils.py
@@ -16,9 +16,9 @@ LOG = logging.getLogger(__name__)
 def chromosome_coverage(samples_ids, chrom=None):
     """Return mean coverage over all transcripts of a chromosome for one or more samples"""
 
-
     query = (
         api.query(
+            TranscriptStat,
             func.avg(TranscriptStat.mean_coverage).label('mean_coverage'),
         )
         .filter(TranscriptStat.sample_id.in_(samples_ids))

--- a/chanjo_report/server/blueprints/report/utils.py
+++ b/chanjo_report/server/blueprints/report/utils.py
@@ -20,11 +20,19 @@ def chromosome_coverage(chrom, *samples_ids):
         api.query(
             TranscriptStat,
             func.avg(TranscriptStat.mean_coverage).label('mean_coverage'),
+            func.avg(TranscriptStat.completeness_10).label('completeness_10'),
+            func.avg(TranscriptStat.completeness_15).label('completeness_15'),
+            func.avg(TranscriptStat.completeness_20).label('completeness_20'),
+            func.avg(TranscriptStat.completeness_50).label('completeness_50'),
+            func.avg(TranscriptStat.completeness_100).label('completeness_100'),
         )
         .filter(TranscriptStat.sample_id.in_(samples_ids))
-        .filter(Transcript.chromosome == chrom)
         .group_by(TranscriptStat.sample_id)
     )
+
+    # limit the search to the given chromosome
+    query = (query.join(TranscriptStat.transcript)
+                     .filter(Transcript.chromsoome == chrom))
     return query
 
 

--- a/chanjo_report/server/blueprints/report/utils.py
+++ b/chanjo_report/server/blueprints/report/utils.py
@@ -26,9 +26,9 @@ def chromosome_coverage(api, chrom, *sample_ids):
         .group_by(TranscriptStat.sample_id)
     )
     return query
-    
 
-def transcript_coverage(api, gene_id, *sample_ids):
+
+def transcript_coverage(gene_id, *sample_ids):
     """Return coverage metrics per transcript for a given gene."""
     query = (api.query(TranscriptStat)
                 .join(TranscriptStat.transcript)

--- a/chanjo_report/server/blueprints/report/utils.py
+++ b/chanjo_report/server/blueprints/report/utils.py
@@ -13,6 +13,20 @@ from chanjo_report.server.extensions import api
 
 LOG = logging.getLogger(__name__)
 
+def chromosome_coverage(api, chrom, *sample_ids):
+    """Return mean coverage over all transcripts of a chromosome for one or more samples"""
+
+    query = (
+        api.query(
+            TranscriptStat,
+            func.avg(TranscriptStat.mean_coverage).label('mean_coverage'),
+        )
+        .filter(TranscriptStat.sample_id.in_(samples_ids))
+        .filter(Transcript.chromosome == chrom)
+        .group_by(TranscriptStat.sample_id)
+    )
+    return query
+    
 
 def transcript_coverage(api, gene_id, *sample_ids):
     """Return coverage metrics per transcript for a given gene."""

--- a/chanjo_report/server/blueprints/report/utils.py
+++ b/chanjo_report/server/blueprints/report/utils.py
@@ -13,7 +13,7 @@ from chanjo_report.server.extensions import api
 
 LOG = logging.getLogger(__name__)
 
-def chromosome_coverage(api, chrom, *sample_ids):
+def chromosome_coverage(chrom, *sample_ids):
     """Return mean coverage over all transcripts of a chromosome for one or more samples"""
 
     query = (
@@ -28,7 +28,7 @@ def chromosome_coverage(api, chrom, *sample_ids):
     return query
 
 
-def transcript_coverage(gene_id, *sample_ids):
+def transcript_coverage(api, gene_id, *sample_ids):
     """Return coverage metrics per transcript for a given gene."""
     query = (api.query(TranscriptStat)
                 .join(TranscriptStat.transcript)

--- a/chanjo_report/server/blueprints/report/utils.py
+++ b/chanjo_report/server/blueprints/report/utils.py
@@ -13,8 +13,9 @@ from chanjo_report.server.extensions import api
 
 LOG = logging.getLogger(__name__)
 
-def chromosome_coverage(chrom, *samples_ids):
+def chromosome_coverage(samples_ids, chrom=None):
     """Return mean coverage over all transcripts of a chromosome for one or more samples"""
+
 
     query = (
         api.query(
@@ -30,11 +31,10 @@ def chromosome_coverage(chrom, *samples_ids):
         .group_by(TranscriptStat.sample_id)
     )
 
-    # limit the search to the given chromosome
     query = (query.join(TranscriptStat.transcript)
-                     .filter(Transcript.chromosome == chrom))
-    return query
+        .filter(Transcript.chromosome == chrom))
 
+    return query
 
 def transcript_coverage(api, gene_id, *sample_ids):
     """Return coverage metrics per transcript for a given gene."""

--- a/chanjo_report/server/blueprints/report/utils.py
+++ b/chanjo_report/server/blueprints/report/utils.py
@@ -32,7 +32,7 @@ def chromosome_coverage(chrom, *samples_ids):
 
     # limit the search to the given chromosome
     query = (query.join(TranscriptStat.transcript)
-                     .filter(Transcript.chromsoome == chrom))
+                     .filter(Transcript.chromosome == chrom))
     return query
 
 

--- a/chanjo_report/server/blueprints/report/utils.py
+++ b/chanjo_report/server/blueprints/report/utils.py
@@ -19,13 +19,7 @@ def chromosome_coverage(samples_ids, chrom=None):
 
     query = (
         api.query(
-            TranscriptStat,
             func.avg(TranscriptStat.mean_coverage).label('mean_coverage'),
-            func.avg(TranscriptStat.completeness_10).label('completeness_10'),
-            func.avg(TranscriptStat.completeness_15).label('completeness_15'),
-            func.avg(TranscriptStat.completeness_20).label('completeness_20'),
-            func.avg(TranscriptStat.completeness_50).label('completeness_50'),
-            func.avg(TranscriptStat.completeness_100).label('completeness_100'),
         )
         .filter(TranscriptStat.sample_id.in_(samples_ids))
         .group_by(TranscriptStat.sample_id)

--- a/chanjo_report/server/blueprints/report/views.py
+++ b/chanjo_report/server/blueprints/report/views.py
@@ -88,10 +88,12 @@ def json_chrom_coverage():
     sample_ids = data.get('sample_ids').split(",")
 
     metrics_rows = chromosome_coverage(chrom, sample_ids).all()
+    """
     for row in metrics_rows:
         ts = row[0] # An object of class TranscriptStat
         results[ts.sample_id] = ts.mean_coverage
-    return jsonify(results)
+    """
+    return str(metrics_rows)
 
 
 @report_bp.route('/json_gene_coverage', methods=['POST'])

--- a/chanjo_report/server/blueprints/report/views.py
+++ b/chanjo_report/server/blueprints/report/views.py
@@ -86,18 +86,13 @@ def json_chrom_coverage():
 
     chrom = str(data.get('chrom'))
     sample_ids = data.get('sample_ids').split(",")
-    appo = ""
-    try:
-        metrics_rows = chromosome_coverage(sample_ids, chrom).all()
-        appo = str(metrics_rows)
-    except Exception as ex:
-        appo = str(ex)
-    """
+
+    metrics_rows = chromosome_coverage(sample_ids, chrom).all()
     for row in metrics_rows:
         ts = row[0] # An object of class TranscriptStat
-        results[ts.sample_id] = ts.mean_coverage
-    """
-    return appo
+        results[ts.sample_id] = row[1]
+
+    return jsonify(results)
 
 
 @report_bp.route('/json_gene_coverage', methods=['POST'])
@@ -116,7 +111,7 @@ def json_gene_coverage():
 
     for row in metrics_rows:
         ts = row[0] # An object of class TranscriptStat
-        results[ts.sample_id] = ts.mean_coverage # Collect mean coverage over the genes
+        results[ts.sample_id] = row[1] # Collect mean coverage over the genes
     return jsonify(results)
 
 

--- a/chanjo_report/server/blueprints/report/views.py
+++ b/chanjo_report/server/blueprints/report/views.py
@@ -86,14 +86,18 @@ def json_chrom_coverage():
 
     chrom = str(data.get('chrom'))
     sample_ids = data.get('sample_ids').split(",")
-
-    metrics_rows = chromosome_coverage(chrom, sample_ids).all()
+    appo = ""
+    try:
+        metrics_rows = chromosome_coverage(chrom, sample_ids).all()
+        appo = str(metrics_rows)
+    except Exception as ex:
+        appo = str(ex)
     """
     for row in metrics_rows:
         ts = row[0] # An object of class TranscriptStat
         results[ts.sample_id] = ts.mean_coverage
     """
-    return str(metrics_rows)
+    return appo
 
 
 @report_bp.route('/json_gene_coverage', methods=['POST'])

--- a/chanjo_report/server/blueprints/report/views.py
+++ b/chanjo_report/server/blueprints/report/views.py
@@ -68,16 +68,6 @@ def genes():
 def json_chrom_coverage():
     """Calculate mean coverage over all gene transcripts of a chromosome for one or more samples and return results as json"""
 
-    """
-    mysql> select avg(mean_coverage) from transcript_stat where sample_id in ("ADM1059A4","ADM1059A5","ADM1059A6") and transcript_id in (select id from transcript where chromosome = "21") group by sample_id;
-    +--------------------+
-    | avg(mean_coverage) |
-    +--------------------+
-    | 36.267719639154116 |
-    |  32.74595301675494 |
-    |  34.07254707284004 |
-    +--------------------+
-    """
     results = {}
     data = request.json
 
@@ -90,7 +80,7 @@ def json_chrom_coverage():
     metrics_rows = chromosome_coverage(sample_ids, chrom).all()
     for row in metrics_rows:
         ts = row[0] # An object of class TranscriptStat
-        results[ts.sample_id] = row[1]
+        results[ts.sample_id] = row[1] # Collect mean coverage over the chromosome transcripts
 
     return jsonify(results)
 

--- a/chanjo_report/server/blueprints/report/views.py
+++ b/chanjo_report/server/blueprints/report/views.py
@@ -76,7 +76,7 @@ def json_chrom_coverage():
     chrom = str(data.get('chrom'))
     sample_ids = data.get('sample_ids').split(",")
 
-    metrics_rows = chromosome_coverage(chrom, sample_ids)
+    metrics_rows = chromosome_coverage(chrom, sample_ids).all()
     for row in metrics_rows:
         ts = row[0] # An object of class TranscriptStat
         results[ts.sample_id] = ts.mean_coverage

--- a/chanjo_report/server/blueprints/report/views.py
+++ b/chanjo_report/server/blueprints/report/views.py
@@ -71,7 +71,7 @@ def json_chrom_coverage():
     results = {}
     data = request.json
 
-    if data.get('chrom') is None or data.get('sample_ids') is None:
+    if not (data.get('chrom') and data.get('sample_ids')):
         return jsonify(results)
 
     chrom = str(data.get('chrom'))

--- a/chanjo_report/server/blueprints/report/views.py
+++ b/chanjo_report/server/blueprints/report/views.py
@@ -88,7 +88,7 @@ def json_chrom_coverage():
     sample_ids = data.get('sample_ids').split(",")
     appo = ""
     try:
-        metrics_rows = chromosome_coverage(chrom, sample_ids).all()
+        metrics_rows = chromosome_coverage(sample_ids, chrom).all()
         appo = str(metrics_rows)
     except Exception as ex:
         appo = str(ex)


### PR DESCRIPTION
### This PR adds | fixes:
- Adds an endpoint that calculates the mean coverage over all transcripts of an entire chromosome for one or more samples and returns it as json.

- Fixes an error on the endpoint that collects the coverage over genes and returns a json object.

**How to prepare for test**:
- [x] from user hiseq.clinical, install the branch on clinical-db stage, install the branch mt_vs_automosome_coverage of scout:
```
cd home/hiseq.clinical/servers/resources/clinical-db.scilifelab.se
bash update-scout-stage.sh mt_vs_automosome_coverage
```
- [x] Then install this chanjo-report branch on clinical-db stage:
`bash update-chanjo-report-stage.sh chrom_coverage_as_json`

### How to test:
#### Test number 1: get chromosome coverage for all samples of a case. Example: chromosome 21 and samples from this case: https://scout-stage.scilifelab.se/cust000/643594-300M
- [x] From a terminal window (clinical-db stage environment) run the curl POST request:
```
curl -i -H "Content-Type: application/json" -X POST \
-d '{"sample_ids":"ADM1059A4,ADM1059A5,ADM1059A6", "chrom": "21"}' \
https://scout-stage.scilifelab.se/reports/json_chrom_coverage
```

#### Test number 2. Fix to the gene coverage endpoint -> Get the coverage for samples of the same case over one gene (example POT1 hgnc id: 17284) using this request from same terminal:

```
curl -i -H "Content-Type: application/json" -X POST \
-d '{"sample_ids":"ADM1059A4,ADM1059A5,ADM1059A6", "gene_ids": "17284"}' \
https://scout-stage.scilifelab.se/reports/json_gene_coverage
```

and compare to value from scout coverage report.

### Expected outcome:
- [x] test 1: A json object with sample coverage over chr 21 should be returned
- [x] test 2: Gene coverage returned by json object should be the same as the one in scout coverage report

### Review:
- [ ] Code approved by
- [x] Tests executed by CR
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
