### PR TITLE
Added docker-compose and Makefile to launch its containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change log
 
-## 4.7 (2020-11-20)
+## 4.8 (2020-11-20)
 ### Added
 - docker-compose and Makefile
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change log
 
-## 4.7 ()
+## 4.7 (2020-11-20)
 ### Added
 - docker-compose and Makefile
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change log
 
+## 4.7 ()
+### Added
+- docker-compose and Makefile
+### Changed
+- Removed ENTRYPOINT from Dockerfile
+
 ## 4.7 (2020-11-16)
 ### Added
 - Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,3 @@ RUN pip install --editable .
 RUN useradd worker
 RUN chown worker:worker -R /home/worker
 USER worker
-
-#ENTRYPOINT ["chanjo", "report"]
-#CMD ["--help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,5 +20,5 @@ RUN useradd worker
 RUN chown worker:worker -R /home/worker
 USER worker
 
-ENTRYPOINT ["chanjo", "report"]
-CMD ["--help"]
+#ENTRYPOINT ["chanjo", "report"]
+#CMD ["--help"]

--- a/Makefile
+++ b/Makefile
@@ -15,11 +15,8 @@ setup: ## Use Chanjo to set up a mysql database containing demo data
 	docker-compose run chanjo-cli chanjo -d mysql+pymysql://chanjoUser:chanjoPassword@mariadb/chanjo4_test load -n sample2 --group-name test_group -g test_group chanjo/init/demo-files/sample2.coverage.bed
 	docker-compose run chanjo-cli chanjo -d mysql+pymysql://chanjoUser:chanjoPassword@mariadb/chanjo4_test load -n sample3 --group-name test_group -b test_group chanjo/init/demo-files/sample3.coverage.bed
 
-report-html: ## Create a coverage report in HTML format
-	docker-compose run -p 5000:5000 chanjo-report chanjo -d mysql+pymysql://chanjoUser:chanjoPassword@mariadb/chanjo4_test report --render html
-
-report-pdf: ## Create a coverage report in PDF format
-	docker-compose run -p 5050:5050 chanjo-report chanjo -d mysql+pymysql://chanjoUser:chanjoPassword@mariadb/chanjo4_test report --render pdf
+report: ## Create a coverage report in HTML format
+	docker-compose run -p 5000:5000 chanjo-report chanjo -d mysql+pymysql://chanjoUser:chanjoPassword@mariadb/chanjo4_test report --render htmls
 
 prune: ## Remove orphans and dangling images
 	docker-compose down --remove-orphans

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ setup: ## Use Chanjo to set up a mysql database containing demo data
 	docker-compose run chanjo-cli chanjo -d mysql+pymysql://chanjoUser:chanjoPassword@mariadb/chanjo4_test load -n sample3 --group-name test_group -b test_group chanjo/init/demo-files/sample3.coverage.bed
 
 report: ## Create a coverage report in HTML format
-	docker-compose run -p 5000:5000 chanjo-report chanjo -d mysql+pymysql://chanjoUser:chanjoPassword@mariadb/chanjo4_test report --render htmls
+	docker-compose run -p 5000:5000 chanjo-report chanjo -d mysql+pymysql://chanjoUser:chanjoPassword@mariadb/chanjo4_test report --render html
 
 prune: ## Remove orphans and dangling images
 	docker-compose down --remove-orphans

--- a/Makefile
+++ b/Makefile
@@ -11,14 +11,14 @@ setup: ## Use Chanjo to set up a mysql database containing demo data
 	echo "Setup chanjo database"
 	docker-compose run chanjo-cli /bin/bash -c "chanjo -d mysql+pymysql://chanjoUser:chanjoPassword@mariadb/chanjo4_test init --auto demodata && chanjo --config demodata/chanjo.yaml link demodata/hgnc.grch37p13.exons.bed"
 	echo "Loading coverage from demo files"
-	docker-compose run chanjo-cli chanjo -d mysql+pymysql://chanjoUser:chanjoPassword@mariadb/chanjo4_test load -s sample1 -g test_group chanjo/init/demo-files/sample1.coverage.bed
-	docker-compose run chanjo-cli chanjo -d mysql+pymysql://chanjoUser:chanjoPassword@mariadb/chanjo4_test load -s sample2 -g test_group chanjo/init/demo-files/sample2.coverage.bed
-	docker-compose run chanjo-cli chanjo -d mysql+pymysql://chanjoUser:chanjoPassword@mariadb/chanjo4_test load -s sample3 -g test_group chanjo/init/demo-files/sample3.coverage.bed
+	docker-compose run chanjo-cli chanjo -d mysql+pymysql://chanjoUser:chanjoPassword@mariadb/chanjo4_test load -n sample1 --group-name test_group -g test_group chanjo/init/demo-files/sample1.coverage.bed
+	docker-compose run chanjo-cli chanjo -d mysql+pymysql://chanjoUser:chanjoPassword@mariadb/chanjo4_test load -n sample2 --group-name test_group -g test_group chanjo/init/demo-files/sample2.coverage.bed
+	docker-compose run chanjo-cli chanjo -d mysql+pymysql://chanjoUser:chanjoPassword@mariadb/chanjo4_test load -n sample3 --group-name test_group -b test_group chanjo/init/demo-files/sample3.coverage.bed
 
 report-html: ## Create a coverage report in HTML format
 	docker-compose run -p 5000:5000 chanjo-report chanjo -d mysql+pymysql://chanjoUser:chanjoPassword@mariadb/chanjo4_test report --render html
 
-report-pdf: ## Create a coverage report in HTML format
+report-pdf: ## Create a coverage report in PDF format
 	docker-compose run -p 5050:5050 chanjo-report chanjo -d mysql+pymysql://chanjoUser:chanjoPassword@mariadb/chanjo4_test report --render pdf
 
 prune: ## Remove orphans and dangling images

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+.PHONY: help build setup report-html report-pdf
+.DEFAULT_GOAL := help
+
+help:
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+build: ## Build chanjo-report Docker Image
+	docker-compose build
+
+setup: ## Use Chanjo to set up a mysql database containing demo data
+	echo "Setup chanjo database"
+	docker-compose run chanjo-cli /bin/bash -c "chanjo -d mysql+pymysql://chanjoUser:chanjoPassword@mariadb/chanjo4_test init --auto demodata && chanjo --config demodata/chanjo.yaml link demodata/hgnc.grch37p13.exons.bed"
+	echo "Loading coverage from demo files"
+	docker-compose run chanjo-cli chanjo -d mysql+pymysql://chanjoUser:chanjoPassword@mariadb/chanjo4_test load -s sample1 -g test_group chanjo/init/demo-files/sample1.coverage.bed
+	docker-compose run chanjo-cli chanjo -d mysql+pymysql://chanjoUser:chanjoPassword@mariadb/chanjo4_test load -s sample2 -g test_group chanjo/init/demo-files/sample2.coverage.bed
+	docker-compose run chanjo-cli chanjo -d mysql+pymysql://chanjoUser:chanjoPassword@mariadb/chanjo4_test load -s sample3 -g test_group chanjo/init/demo-files/sample3.coverage.bed
+
+report-html: ## Create a coverage report in HTML format
+	docker-compose run -p 5000:5000 chanjo-report chanjo -d mysql+pymysql://chanjoUser:chanjoPassword@mariadb/chanjo4_test report --render html
+
+report-pdf: ## Create a coverage report in HTML format
+	docker-compose run -p 5050:5050 chanjo-report chanjo -d mysql+pymysql://chanjoUser:chanjoPassword@mariadb/chanjo4_test report --render pdf
+
+prune: ## Remove orphans and dangling images
+	docker-compose down --remove-orphans
+	docker images prune

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,31 +3,45 @@ version: '3'
 # (sudo) docker-compose up -d
 # (sudo) docker-compose down
 services:
-    mysql_db:
-      container_name: mysql_db
-      image: mysql:5.7
+    mariadb:
+      container_name: mariadb
+      image: mariadb:latest
       restart: 'always'
-      expose:
-        - '3307'
-      ports:
-        - '3307:3306'
       environment:
-         MYSQL_ROOT_PASSWORD: 'password'
-         MYSQL_DATABASE: 'chanjo_test'
-         MYSQL_USER: 'testUser'
-         MYSQL_PASSWORD: 'testPass'
+        - MYSQL_ROOT_PASSWORD=root
+        - MYSQL_DATABASE=chanjo4_test
+        - MYSQL_USER=chanjoUser
+        - MYSQL_PASSWORD=chanjoPassword
+      healthcheck: # Wait for the service to be ready before accepting incoming connections
+        test: "mysql --user=chanjoUser --password=chanjoPassword --execute \"SHOW DATABASES;\""
+        timeout: 10s
+        retries: 20
       networks:
         - chanjo-net
 
-    chanjo_cli:
-      container_name: chanjo_cli
+    chanjo-cli:
+      container_name: chanjo-cli
       image: northwestwitch/chanjo
-      command: chanjo --database "mysql+pymysql://testUser:testPass@127.0.0.1:3307/chanjo4" init --auto
+      depends_on:
+        mariadb:
+          condition: service_healthy # DB_URI=mysql+pymysql://chanjoUser:chanjoPassword@mariadb/chanjo4_test
       networks:
         - chanjo-net
+
+    chanjo-report:
+      container_name: chanjo-report
+      build:
+        context: .
+        dockerfile: Dockerfile
       depends_on:
-        - mysql_db
+        - mariadb
+      networks:
+        - chanjo-net
 
 networks:
   chanjo-net:
     driver: bridge
+    ipam:
+      driver: default
+      config:
+        - subnet: 172.21.0.0/24

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,33 @@
+version: '3'
+# usage:
+# (sudo) docker-compose up -d
+# (sudo) docker-compose down
+services:
+    mysql_db:
+      container_name: mysql_db
+      image: mysql:5.7
+      restart: 'always'
+      expose:
+        - '3307'
+      ports:
+        - '3307:3306'
+      environment:
+         MYSQL_ROOT_PASSWORD: 'password'
+         MYSQL_DATABASE: 'chanjo_test'
+         MYSQL_USER: 'testUser'
+         MYSQL_PASSWORD: 'testPass'
+      networks:
+        - chanjo-net
+
+    chanjo_cli:
+      container_name: chanjo_cli
+      image: northwestwitch/chanjo
+      command: chanjo --database "mysql+pymysql://testUser:testPass@127.0.0.1:3307/chanjo4" init --auto
+      networks:
+        - chanjo-net
+      depends_on:
+        - mysql_db
+
+networks:
+  chanjo-net:
+    driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
 
     chanjo-cli:
       container_name: chanjo-cli
-      image: northwestwitch/chanjo
+      image: clinicalgenomics/chanjo
       depends_on:
         mariadb:
           condition: service_healthy # DB_URI=mysql+pymysql://chanjoUser:chanjoPassword@mariadb/chanjo4_test


### PR DESCRIPTION
### This PR adds | fixes:
- Adds a docker-compose to illustrate how to use the Docker image linked to a MySQL database
- Provides a Makefile that helps running containers

**How to prepare for test**:
- [x] Run `make` and see the available options
- [x] build the Dockerfile using the command `make build`

### How to test:
- [x] Set up a demo MySQL database and populate with demo data by running the command `make setup`
- [x] Lauch the report app by running `make report`

### Expected outcome:
- [x] Go to the provided link on a browser and make sure that the report exists
- [x] Run `make prune` to stop and remove all containers

### Review:
- [x] Code approved by MM
- [x] Tests executed by CR
- [x] "Merge and deploy" approved by MM

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
