### PR TITLE
Use an up-to-date chanjo version in chanjo-report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 4.8.1 (2021-07-08)
+### Fixed
+- Temporary fix in setup.py to use an up-to-date version of chanjo when the reports are created
+
 ## 4.8 (2020-11-20)
 ### Added
 - docker-compose and Makefile

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ LABEL about.home="https://github.com/Clinical-Genomics/chanjo-report"
 
 # Install required libs
 RUN apt-get update && apt-get install -y \
-  libcairo2 libpango-1.0-0 libpangocairo-1.0-0
+  libcairo2 libpango-1.0-0 libpangocairo-1.0-0 git
 
 WORKDIR /home/worker/app
 COPY . /home/worker/app

--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,13 @@ setup: ## Use Chanjo to set up a mysql database containing demo data
 	echo "Loading coverage from demo files"
 	docker-compose run chanjo-cli chanjo -d mysql+pymysql://chanjoUser:chanjoPassword@mariadb/chanjo4_test load -n sample1 --group-name test_group -g test_group chanjo/init/demo-files/sample1.coverage.bed
 	docker-compose run chanjo-cli chanjo -d mysql+pymysql://chanjoUser:chanjoPassword@mariadb/chanjo4_test load -n sample2 --group-name test_group -g test_group chanjo/init/demo-files/sample2.coverage.bed
-	docker-compose run chanjo-cli chanjo -d mysql+pymysql://chanjoUser:chanjoPassword@mariadb/chanjo4_test load -n sample3 --group-name test_group -b test_group chanjo/init/demo-files/sample3.coverage.bed
+	docker-compose run chanjo-cli chanjo -d mysql+pymysql://chanjoUser:chanjoPassword@mariadb/chanjo4_test load -n sample3 --group-name test_group -g test_group chanjo/init/demo-files/sample3.coverage.bed
 
 report: ## Create a coverage report in HTML format
 	docker-compose run -p 5000:5000 chanjo-report chanjo -d mysql+pymysql://chanjoUser:chanjoPassword@mariadb/chanjo4_test report --render html
+
+chanjo-version: # print the version of chanjo installed in the chanjo-report
+		docker-compose run chanjo-report chanjo  --version
 
 prune: ## Remove orphans and dangling images
 	docker-compose down --remove-orphans

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,9 +30,7 @@ services:
 
     chanjo-report:
       container_name: chanjo-report
-      build:
-        context: .
-        dockerfile: Dockerfile
+      build: .
       depends_on:
         - mariadb
       networks:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 -r requirements/conda.txt
 
-chanjo>=4.1.0
 Flask-WeasyPrint
 Flask-Assets
 Flask-Babel

--- a/setup.py
+++ b/setup.py
@@ -3,13 +3,14 @@
 """Based on https://github.com/pypa/sampleproject/blob/master/setup.py."""
 import codecs
 import os
-from setuptools import setup, find_packages
-from setuptools.command.test import test as TestCommand
 import sys
 
+from setuptools import find_packages, setup
+from setuptools.command.test import test as TestCommand
+
 # shortcut for building/publishing to Pypi
-if sys.argv[-1] == 'publish':
-    os.system('python setup.py sdist bdist_wheel upload')
+if sys.argv[-1] == "publish":
+    os.system("python setup.py sdist bdist_wheel upload")
     sys.exit()
 
 
@@ -18,7 +19,7 @@ class PyTest(TestCommand):
 
     """Set up the py.test test runner."""
 
-    user_options = [('pytest-args=', 'a', 'Arguments to pass to py.test')]
+    user_options = [("pytest-args=", "a", "Arguments to pass to py.test")]
 
     def initialize_options(self):
         TestCommand.initialize_options(self)
@@ -34,68 +35,69 @@ class PyTest(TestCommand):
         """Execute the test runner command."""
         # import here, because outside the required eggs aren't loaded yet
         import pytest
+
         sys.exit(pytest.main(self.test_args))
 
 
 # get the long description from the relevant file
 HERE = os.path.abspath(os.path.dirname(__file__))
-with codecs.open(os.path.join(HERE, 'README.md'), encoding='utf-8') as f:
+with codecs.open(os.path.join(HERE, "README.md"), encoding="utf-8") as f:
     LONG_DESCRIPTION = f.read()
 
 
-setup(name='chanjo-report',
-      # versions should comply with PEP440
-      version='4.7.0',
-      description='Automatically render coverage reports from Chanjo ouput',
-      long_description=LONG_DESCRIPTION,
-      # what does your project relate to?
-      keywords='chanjo-report development',
-      author='Robin Andeer',
-      author_email='robin.andeer@scilifelab.se',
-      license='MIT',
-      # the project's main homepage
-      url='https://github.com/robinandeer/chanjo-report',
-      packages=find_packages(exclude=('tests*', 'docs', 'examples')),
-      # if there are data files included in your packages
-      include_package_data=True,
-      package_data={
-          'chanjo_report': [
-              'server/blueprints/report/static/*.css',
-              'server/blueprints/report/static/vendor/*.css',
-              'server/blueprints/report/templates/report/*.html',
-              'server/blueprints/report/templates/report/layouts/*.html',
-              'server/blueprints/report/templates/report/components/*.html',
-              'server/translations/sv/LC_MESSAGES/*',
-          ]
-      },
-      zip_safe=False,
-      install_requires=[
-          'setuptools',
-          'chanjo>=4.1.0',
-          'Flask-WeasyPrint',
-          'cairocffi',
-          'lxml>=3.0',
-          'cffi',
-          'Flask',
-          'SQLAlchemy',
-          'Flask-Babel',
-          'tabulate',
-          'Flask-Alchy',
-          'Flask-SQLAlchemy==2.1',
-          'pymysql',
-      ],
-      tests_require=['pytest'],
-      cmdclass={'test': PyTest},
-      # to provide executable scripts, use entry points
-      entry_points={
-          'chanjo.subcommands.4': ['report = chanjo_report.cli:report'],
-      },
-      # see: http://pypi.python.org/pypi?%3Aaction=list_classifiers
-      classifiers=[
-          'Development Status :: 3 - Alpha',
-          'Intended Audience :: Developers',
-          'Topic :: Software Development',
-          'License :: OSI Approved :: MIT License',
-          'Programming Language :: Python :: 3.6',
-          'Environment :: Console'
-      ])
+setup(
+    name="chanjo-report",
+    # versions should comply with PEP440
+    version="4.7.0",
+    description="Automatically render coverage reports from Chanjo ouput",
+    long_description=LONG_DESCRIPTION,
+    # what does your project relate to?
+    keywords="chanjo-report development",
+    author="Robin Andeer",
+    author_email="robin.andeer@scilifelab.se",
+    license="MIT",
+    # the project's main homepage
+    url="https://github.com/robinandeer/chanjo-report",
+    packages=find_packages(exclude=("tests*", "docs", "examples")),
+    # if there are data files included in your packages
+    include_package_data=True,
+    package_data={
+        "chanjo_report": [
+            "server/blueprints/report/static/*.css",
+            "server/blueprints/report/static/vendor/*.css",
+            "server/blueprints/report/templates/report/*.html",
+            "server/blueprints/report/templates/report/layouts/*.html",
+            "server/blueprints/report/templates/report/components/*.html",
+            "server/translations/sv/LC_MESSAGES/*",
+        ]
+    },
+    zip_safe=False,
+    install_requires=[
+        "chanjo @ git+https://github.com/Clinical-Genomics/chanjo.git#egg=repo-4.6.1",  # Temporary fix due to outdated chanjo on PyPI
+        "setuptools",
+        "Flask-WeasyPrint",
+        "cairocffi",
+        "lxml>=3.0",
+        "cffi",
+        "Flask",
+        "SQLAlchemy",
+        "Flask-Babel",
+        "tabulate",
+        "Flask-Alchy",
+        "Flask-SQLAlchemy==2.1",
+        "pymysql",
+    ],
+    tests_require=["pytest"],
+    cmdclass={"test": PyTest},
+    # to provide executable scripts, use entry points
+    entry_points={"chanjo.subcommands.4": ["report = chanjo_report.cli:report"],},
+    # see: http://pypi.python.org/pypi?%3Aaction=list_classifiers
+    classifiers=[
+        "Development Status :: 3 - Alpha",
+        "Intended Audience :: Developers",
+        "Topic :: Software Development",
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python :: 3.6",
+        "Environment :: Console",
+    ],
+)


### PR DESCRIPTION
### This PR adds | fixes:
- chanjo-report is currently broken when installed in a fresh environment or used from Docker. This is due to an [issue in chanjo](https://github.com/Clinical-Genomics/chanjo/pull/233) that has been fixed today. The problem with this repo now is that **it is still using an old version of chanjo since it is pulling it from PyPI and PyPI doesn't contain the latest versions**. 
- We are waiting to push to PyPI the latest version of chanjo, but since we don't have the permissions, **this is a temporary fix** that will make this repo works.
- Fix intended for CG Lund

**How to prepare for test**:
- [ ] Remove all chanjo-report and chanjo containers and images on you system
### How to test:
- [ ] create the containers with the command: `docker-compose up` 
- [ ] Make sure that the version of chanjo used in the repo is the latest: 4.6.1 :  `make chanjo-version`
- [ ] Set up chanjo with some demo data: `make setup`
- [ ] Create the demo report with the command: `make report`

### Expected outcome:
- [ ] The report should work

### Review:
- [ ] Code approved by
- [ ] Tests executed by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
