### PR TITLE
Prepare version 4.9 with autopush to PyPI

### DIFF
--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -1,0 +1,40 @@
+name: Build and Publish to PyPI
+
+on:
+ release:
+  types:
+   - created
+
+jobs:
+ build-n-publish:
+  name: Build and publish Python distribution to PyPI
+  runs-on: ubuntu-18.04
+  steps:
+   - name: Check out git repository
+     uses: actions/checkout@v2
+
+   - name: Set up Python 3.7
+     uses: actions/setup-python@v2
+     with:
+      python-version: 3.7
+
+   - name: Install build tools
+     run: >-
+        python -m
+        pip install
+        wheel
+        twine
+        --user
+
+   - name: Build a binary wheel and a source tarball
+     run: >-
+        python
+        setup.py
+        sdist
+        bdist_wheel
+
+   - name: Publish distribution 📦 to PyPI
+     uses: pypa/gh-action-pypi-publish@master
+     with:
+       user: __token__
+       password: ${{ secrets.pypi_password }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change log
 
-## 4.9 (2020-11-20)
+## 4.9 (2022-01-19)
 - GitHub action to push repo to PyPI on new release event
 
 ## 4.8 (2020-11-20)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change log
 
+## 4.9 (2020-11-20)
+- GitHub action to push repo to PyPI on new release event
+
 ## 4.8 (2020-11-20)
 ### Added
 - docker-compose and Makefile

--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,8 @@ from setuptools.command.test import test as TestCommand
 import sys
 
 # shortcut for building/publishing to Pypi
-if sys.argv[-1] == 'publish':
-    os.system('python setup.py sdist bdist_wheel upload')
+if sys.argv[-1] == "publish":
+    os.system("python setup.py sdist bdist_wheel upload")
     sys.exit()
 
 
@@ -18,7 +18,7 @@ class PyTest(TestCommand):
 
     """Set up the py.test test runner."""
 
-    user_options = [('pytest-args=', 'a', 'Arguments to pass to py.test')]
+    user_options = [("pytest-args=", "a", "Arguments to pass to py.test")]
 
     def initialize_options(self):
         TestCommand.initialize_options(self)
@@ -34,68 +34,71 @@ class PyTest(TestCommand):
         """Execute the test runner command."""
         # import here, because outside the required eggs aren't loaded yet
         import pytest
+
         sys.exit(pytest.main(self.test_args))
 
 
 # get the long description from the relevant file
 HERE = os.path.abspath(os.path.dirname(__file__))
-with codecs.open(os.path.join(HERE, 'README.md'), encoding='utf-8') as f:
+with codecs.open(os.path.join(HERE, "README.md"), encoding="utf-8") as f:
     LONG_DESCRIPTION = f.read()
 
 
-setup(name='chanjo-report',
-      # versions should comply with PEP440
-      version='4.7.0',
-      description='Automatically render coverage reports from Chanjo ouput',
-      long_description=LONG_DESCRIPTION,
-      # what does your project relate to?
-      keywords='chanjo-report development',
-      author='Robin Andeer',
-      author_email='robin.andeer@scilifelab.se',
-      license='MIT',
-      # the project's main homepage
-      url='https://github.com/robinandeer/chanjo-report',
-      packages=find_packages(exclude=('tests*', 'docs', 'examples')),
-      # if there are data files included in your packages
-      include_package_data=True,
-      package_data={
-          'chanjo_report': [
-              'server/blueprints/report/static/*.css',
-              'server/blueprints/report/static/vendor/*.css',
-              'server/blueprints/report/templates/report/*.html',
-              'server/blueprints/report/templates/report/layouts/*.html',
-              'server/blueprints/report/templates/report/components/*.html',
-              'server/translations/sv/LC_MESSAGES/*',
-          ]
-      },
-      zip_safe=False,
-      install_requires=[
-          'setuptools',
-          'chanjo>=4.1.0',
-          'Flask-WeasyPrint',
-          'cairocffi',
-          'lxml>=3.0',
-          'cffi',
-          'Flask',
-          'SQLAlchemy',
-          'Flask-Babel',
-          'tabulate',
-          'Flask-Alchy',
-          'Flask-SQLAlchemy==2.1',
-          'pymysql',
-      ],
-      tests_require=['pytest'],
-      cmdclass={'test': PyTest},
-      # to provide executable scripts, use entry points
-      entry_points={
-          'chanjo.subcommands.4': ['report = chanjo_report.cli:report'],
-      },
-      # see: http://pypi.python.org/pypi?%3Aaction=list_classifiers
-      classifiers=[
-          'Development Status :: 3 - Alpha',
-          'Intended Audience :: Developers',
-          'Topic :: Software Development',
-          'License :: OSI Approved :: MIT License',
-          'Programming Language :: Python :: 3.6',
-          'Environment :: Console'
-      ])
+setup(
+    name="chanjo-report",
+    # versions should comply with PEP440
+    version="4.9.0",
+    description="Automatically render coverage reports from Chanjo ouput",
+    long_description=LONG_DESCRIPTION,
+    # what does your project relate to?
+    keywords="chanjo-report development",
+    author="Robin Andeer",
+    author_email="robin.andeer@scilifelab.se",
+    license="MIT",
+    # the project's main homepage
+    url="https://github.com/robinandeer/chanjo-report",
+    packages=find_packages(exclude=("tests*", "docs", "examples")),
+    # if there are data files included in your packages
+    include_package_data=True,
+    package_data={
+        "chanjo_report": [
+            "server/blueprints/report/static/*.css",
+            "server/blueprints/report/static/vendor/*.css",
+            "server/blueprints/report/templates/report/*.html",
+            "server/blueprints/report/templates/report/layouts/*.html",
+            "server/blueprints/report/templates/report/components/*.html",
+            "server/translations/sv/LC_MESSAGES/*",
+        ]
+    },
+    zip_safe=False,
+    install_requires=[
+        "setuptools",
+        "chanjo>=4.1.0",
+        "Flask-WeasyPrint",
+        "cairocffi",
+        "lxml>=3.0",
+        "cffi",
+        "Flask",
+        "SQLAlchemy",
+        "Flask-Babel",
+        "tabulate",
+        "Flask-Alchy",
+        "Flask-SQLAlchemy==2.1",
+        "pymysql",
+    ],
+    tests_require=["pytest"],
+    cmdclass={"test": PyTest},
+    # to provide executable scripts, use entry points
+    entry_points={
+        "chanjo.subcommands.4": ["report = chanjo_report.cli:report"],
+    },
+    # see: http://pypi.python.org/pypi?%3Aaction=list_classifiers
+    classifiers=[
+        "Development Status :: 3 - Alpha",
+        "Intended Audience :: Developers",
+        "Topic :: Software Development",
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python :: 3.6",
+        "Environment :: Console",
+    ],
+)


### PR DESCRIPTION
### This PR adds | fixes:
- GitHub action to push repo on PyPI on new release event (fix #17)

### Review:
- [ ] Code approved by
- [ ] Tests executed by
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
