### PR TITLE
Fix Makefile typo preventing loading of demodata 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log
 
+##
+### Fixed
+- Typo in Makefile preventing loading of demodata
+
+
 ## 4.9 (2022-01-19)
 - GitHub action to push repo to PyPI on new release event
 

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ setup: ## Use Chanjo to set up a mysql database containing demo data
 	echo "Loading coverage from demo files"
 	docker-compose run chanjo-cli chanjo -d mysql+pymysql://chanjoUser:chanjoPassword@mariadb/chanjo4_test load -n sample1 --group-name test_group -g test_group chanjo/init/demo-files/sample1.coverage.bed
 	docker-compose run chanjo-cli chanjo -d mysql+pymysql://chanjoUser:chanjoPassword@mariadb/chanjo4_test load -n sample2 --group-name test_group -g test_group chanjo/init/demo-files/sample2.coverage.bed
-	docker-compose run chanjo-cli chanjo -d mysql+pymysql://chanjoUser:chanjoPassword@mariadb/chanjo4_test load -n sample3 --group-name test_group -b test_group chanjo/init/demo-files/sample3.coverage.bed
+	docker-compose run chanjo-cli chanjo -d mysql+pymysql://chanjoUser:chanjoPassword@mariadb/chanjo4_test load -n sample3 --group-name test_group -g test_group chanjo/init/demo-files/sample3.coverage.bed
 
 report: ## Create a coverage report in HTML format
 	docker-compose run -p 5000:5000 chanjo-report chanjo -d mysql+pymysql://chanjoUser:chanjoPassword@mariadb/chanjo4_test report --render html


### PR DESCRIPTION
###  Fix #20  -- NEEDED TO TEST THE FIX FOR #19

**How to prepare for test**:
- Remove all chanjo-report relelated containers and images you might have locally

### How to test:
- From master branch, run `make setup`, the command should fail
- Remove all broken and dangling containers again
- Switch to this branch and the command should be successful
- Now run `make report` and in the browser type the following URL: `http://localhost:5000/report?sample_id=sample1&sample_id=sample2&sample_id=sample3`

### Expected outcome:
- [x] You should see an HTML report with 3 samples. -- PDF report should show just one sample though --

### Review:
- [x] Code approved by DN
- [x] Tests executed by CR
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
