### PR TITLE
Multisample PDF reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ##
 ### Fixed
 - Typo in Makefile preventing loading of demodata
-
+- Multisample PDF reports
 
 ## 4.9 (2022-01-19)
 - GitHub action to push repo to PyPI on new release event

--- a/chanjo_report/server/blueprints/report/controllers.py
+++ b/chanjo_report/server/blueprints/report/controllers.py
@@ -1,0 +1,56 @@
+from chanjo.store.models import Sample
+from flask import session
+
+from chanjo_report.server.constants import LEVELS
+
+from .utils import keymetrics_rows, samplesex_rows, transcripts_rows
+
+
+def report_contents(request):
+    """Check args or form provided by user request and prepare contents for report or pdf enrpoints
+    Args:
+        request(flask.Request)
+
+    Returns:
+        data(dict)
+    """
+
+    sample_ids = request.args.getlist("sample_id") or request.form.getlist("sample_id")
+    raw_gene_ids = request.args.get("gene_ids") or request.form.get("gene_ids")
+    gene_ids = []
+    if raw_gene_ids:
+        session["all_genes"] = raw_gene_ids
+        gene_ids = [gene_id.strip() for gene_id in raw_gene_ids.split(",")]
+    else:
+        if request.method == "GET" and session.get("all_genes"):
+            gene_ids = [gene_id.strip() for gene_id in session.get("all_genes").split(",")]
+    try:
+        # gene ids should be numerical, if they are strings print error String instead
+        gene_ids = [int(gene_id) for gene_id in gene_ids]
+    except ValueError:
+        return "Gene format not supported. Gene list should contain comma-separated HGNC numerical identifiers, not strings."
+
+    level = int(request.args.get("level") or request.form.get("level") or 10)
+    extras = {
+        "panel_name": (request.args.get("panel_name") or request.form.get("panel_name")),
+        "level": level,
+        "gene_ids": gene_ids,
+        "show_genes": any([request.args.get("show_genes"), request.form.get("show_genes")]),
+    }
+    samples = Sample.query.filter(Sample.id.in_(sample_ids))
+    case_name = request.args.get("case_name") or request.form.get("case_name")
+    sex_rows = samplesex_rows(sample_ids)
+    metrics_rows = keymetrics_rows(sample_ids, genes=gene_ids)
+    tx_rows = transcripts_rows(sample_ids, genes=gene_ids, level=level)
+
+    data = dict(
+        sample_ids=sample_ids,
+        samples=samples,
+        case_name=case_name,
+        sex_rows=sex_rows,
+        levels=LEVELS,
+        extras=extras,
+        metrics_rows=metrics_rows,
+        tx_rows=tx_rows,
+    )
+    return data

--- a/chanjo_report/server/blueprints/report/views.py
+++ b/chanjo_report/server/blueprints/report/views.py
@@ -1,53 +1,66 @@
 # -*- coding: utf-8 -*-
-import logging
 import datetime
-from chanjo.store.models import Transcript, TranscriptStat, Sample
-from flask import abort, Blueprint, render_template, request, url_for, session, jsonify
-from flask_weasyprint import render_pdf
+import logging
+
+from chanjo.store.models import Sample, Transcript, TranscriptStat
+from flask import Blueprint, abort, jsonify, render_template, request, url_for
+from flask_weasyprint import HTML, render_pdf
 
 from chanjo_report.server.extensions import api
-from chanjo_report.server.constants import LEVELS
-from .utils import (samplesex_rows, keymetrics_rows, transcripts_rows, map_samples,
-                    transcript_coverage, chromosome_coverage)
+
+from . import controllers
+from .utils import chromosome_coverage, keymetrics_rows, map_samples, transcript_coverage
 
 logger = logging.getLogger(__name__)
-report_bp = Blueprint('report', __name__, template_folder='templates',
-                      static_folder='static', static_url_path='/static/report')
+report_bp = Blueprint(
+    "report",
+    __name__,
+    template_folder="templates",
+    static_folder="static",
+    static_url_path="/static/report",
+)
 
 
-@report_bp.route('/genes/<gene_id>')
+@report_bp.route("/genes/<gene_id>")
 def gene(gene_id):
     """Display coverage information on a gene."""
-    sample_ids = request.args.getlist('sample_id')
+    sample_ids = request.args.getlist("sample_id")
     sample_dict = map_samples(sample_ids=sample_ids)
     matching_tx = Transcript.filter_by(gene_id=gene_id).first()
     if matching_tx is None:
         return abort(404, "gene not found: {}".format(gene_id))
     gene_name = matching_tx.gene_name
     tx_groups = transcript_coverage(api, gene_id, *sample_ids)
-    link = request.args.get('link')
-    return render_template('report/gene.html', gene_id=gene_id,
-                           gene_name=gene_name, link=link,
-                           tx_groups=tx_groups, samples=sample_dict)
+    link = request.args.get("link")
+    return render_template(
+        "report/gene.html",
+        gene_id=gene_id,
+        gene_name=gene_name,
+        link=link,
+        tx_groups=tx_groups,
+        samples=sample_dict,
+    )
 
 
-@report_bp.route('/genes', methods=['GET', 'POST'])
+@report_bp.route("/genes", methods=["GET", "POST"])
 def genes():
     """Display an overview of genes that are (un)completely covered."""
-    skip = int(request.args.get('skip', 0))
-    limit = int(request.args.get('limit', 30))
-    exonlink = request.args.get('exonlink')
-    sample_ids = request.args.getlist('sample_id')
+    skip = int(request.args.get("skip", 0))
+    limit = int(request.args.get("limit", 30))
+    exonlink = request.args.get("exonlink")
+    sample_ids = request.args.getlist("sample_id")
     samples_q = Sample.filter(Sample.id.in_(sample_ids))
-    level = request.args.get('level', 10)
-    raw_gene_ids = request.args.get('gene_id') or request.form.get('gene_ids')
+    level = request.args.get("level", 10)
+    raw_gene_ids = request.args.get("gene_id") or request.form.get("gene_ids")
     completeness_col = getattr(TranscriptStat, "completeness_{}".format(level))
-    query = (api.query(TranscriptStat)
-                .join(TranscriptStat.transcript)
-                .filter(completeness_col < 100)
-                .order_by(completeness_col))
+    query = (
+        api.query(TranscriptStat)
+        .join(TranscriptStat.transcript)
+        .filter(completeness_col < 100)
+        .order_by(completeness_col)
+    )
 
-    gene_ids = raw_gene_ids.split(',') if raw_gene_ids else []
+    gene_ids = raw_gene_ids.split(",") if raw_gene_ids else []
     if raw_gene_ids:
         query = query.filter(Transcript.gene_id.in_(gene_ids))
     if sample_ids:
@@ -56,106 +69,86 @@ def genes():
     incomplete_left = query.offset(skip).limit(limit)
     total = query.count()
     has_next = total > skip + limit
-    return render_template('report/genes.html', incomplete=incomplete_left,
-                           level=level, skip=skip, limit=limit,
-                           has_next=has_next, gene_ids=gene_ids,
-                           exonlink=exonlink, samples=samples_q,
-                           sample_ids=sample_ids)
+    return render_template(
+        "report/genes.html",
+        incomplete=incomplete_left,
+        level=level,
+        skip=skip,
+        limit=limit,
+        has_next=has_next,
+        gene_ids=gene_ids,
+        exonlink=exonlink,
+        samples=samples_q,
+        sample_ids=sample_ids,
+    )
 
 
-
-@report_bp.route('/json_chrom_coverage', methods=['POST'])
+@report_bp.route("/json_chrom_coverage", methods=["POST"])
 def json_chrom_coverage():
     """Calculate mean coverage over all gene transcripts of a chromosome for one or more samples and return results as json"""
 
     results = {}
     data = request.json
 
-    if not (data.get('chrom') and data.get('sample_ids')):
+    if not (data.get("chrom") and data.get("sample_ids")):
         return jsonify(results)
 
-    chrom = str(data.get('chrom'))
-    sample_ids = data.get('sample_ids').split(",")
+    chrom = str(data.get("chrom"))
+    sample_ids = data.get("sample_ids").split(",")
 
     metrics_rows = chromosome_coverage(sample_ids, chrom).all()
     for row in metrics_rows:
-        ts = row[0] # An object of class TranscriptStat
-        results[ts.sample_id] = row[1] # Collect mean coverage over the chromosome transcripts
+        ts = row[0]  # An object of class TranscriptStat
+        results[ts.sample_id] = row[1]  # Collect mean coverage over the chromosome transcripts
 
     return jsonify(results)
 
 
-@report_bp.route('/json_gene_coverage', methods=['POST'])
+@report_bp.route("/json_gene_coverage", methods=["POST"])
 def json_gene_coverage():
     """Calculate mean coverage over a list of genes for one or more samples and return results as json"""
     results = {}
     data = request.json
 
-    if not (data.get('gene_ids') and data.get('sample_ids')):
+    if not (data.get("gene_ids") and data.get("sample_ids")):
         return jsonify(results)
 
-    gene_ids = data.get('gene_ids').split(",")
-    sample_ids = data.get('sample_ids').split(",")
+    gene_ids = data.get("gene_ids").split(",")
+    sample_ids = data.get("sample_ids").split(",")
 
     metrics_rows = keymetrics_rows(sample_ids, genes=gene_ids).all()
 
     for row in metrics_rows:
-        ts = row[0] # An object of class TranscriptStat
-        results[ts.sample_id] = row[1] # Collect mean coverage over the genes
+        ts = row[0]  # An object of class TranscriptStat
+        results[ts.sample_id] = row[1]  # Collect mean coverage over the genes
     return jsonify(results)
 
 
-@report_bp.route('/report', methods=['GET', 'POST'])
+@report_bp.route("/report", methods=["GET", "POST"])
 def report():
     """Generate a coverage report for a group of samples."""
-    sample_ids = request.args.getlist('sample_id') or request.form.getlist('sample_id')
-    raw_gene_ids = (request.args.get('gene_ids') or request.form.get('gene_ids'))
-    gene_ids = []
-    if raw_gene_ids:
-        session['all_genes'] = raw_gene_ids
-        gene_ids = [gene_id.strip() for gene_id in raw_gene_ids.split(',')]
-    else:
-        if request.method=='GET' and session.get('all_genes'):
-            gene_ids = [gene_id.strip() for gene_id in session.get('all_genes').split(',')]
-    try:
-        # gene ids should be numerical, if they are strings print error String instead
-        gene_ids = [int(gene_id) for gene_id in gene_ids]
-    except ValueError:
-        return "Gene format not supported. Gene list should contain comma-separated HGNC numerical identifiers, not strings."
-
-    level = int(request.args.get('level') or request.form.get('level') or 10)
-    extras = {
-        'panel_name': (request.args.get('panel_name') or request.form.get('panel_name')),
-        'level': level,
-        'gene_ids': gene_ids,
-        'show_genes': any([request.args.get('show_genes'), request.form.get('show_genes')]),
-    }
-    samples = Sample.query.filter(Sample.id.in_(sample_ids))
-    case_name = request.args.get('case_name') or request.form.get('case_name')
-    sex_rows = samplesex_rows(sample_ids)
-    metrics_rows = keymetrics_rows(sample_ids, genes=gene_ids)
-    tx_rows = transcripts_rows(sample_ids, genes=gene_ids, level=level)
-    return render_template('report/report.html', extras=extras,
-                           samples=samples, case_name=case_name, sex_rows=sex_rows,
-                           sample_ids=sample_ids, levels=LEVELS,
-                           metrics_rows=metrics_rows, tx_rows=tx_rows)
+    data = controllers.report_contents(request)
+    return render_template("report/report.html", **data)
 
 
-@report_bp.route('/report/pdf', methods=['GET', 'POST'])
+@report_bp.route("/report/pdf", methods=["GET", "POST"])
 def pdf():
-    data_dict = request.form if request.method == 'POST' else request.args
-    # make a PDF from another view
-    response = render_pdf(url_for('report.report', **data_dict))
+    """Generate a PDF coverage report for a group of samples."""
+    data = controllers.report_contents(request)
+
+    html_report = render_template("report/report.html", **data)
+    response = render_pdf(HTML(string=html_report))
 
     # check if the request is to download the file right away
-    if 'dl' in data_dict:
+    data_dict = request.form if request.method == "POST" else request.args
+    if "dl" in data_dict:
         date_str = str(datetime.datetime.now().strftime("%Y-%m-%d"))
-        fname = '_'.join(['coverage-report', date_str+'.pdf'])
+        fname = "_".join(["coverage-report", date_str + ".pdf"])
 
-        if 'case_name' in data_dict: # if downloaded pdf should be named after a case sisplay name
-            fname = '_'.join([str(data_dict['case_name']),fname])
+        if "case_name" in data_dict:  # if downloaded pdf should be named after a case sisplay name
+            fname = "_".join([str(data_dict["case_name"]), fname])
 
         header = "attachment; filename={}".format(fname)
-        response.headers['Content-Disposition'] = header
+        response.headers["Content-Disposition"] = header
 
     return response


### PR DESCRIPTION
### This PR adds | fixes:
- Fix #19 
- Refractories views so that 2 functions use the same controller to populate report data

The actual bug is in this line: https://github.com/Clinical-Genomics/chanjo-report/blob/254ddb3a73802cf5e94951c04b6ac2754a5db914/chanjo_report/server/blueprints/report/views.py#L148 ---> The data passed to the html report view is a dictionary and not recognized as proper request args or request.form

**How to prepare for test**:
Current master is bugged, to reproduce locally, master branch:
- `make setup`
- 'make report'
- go to [report url](http://localhost:5000/report?sample_id=sample1&sample_id=sample2&sample_id=sample3) and export to PDF

### How to test:
- remove all previous containers
- Switch to this branch and repeat

### Expected outcome:
- A PDF report with 3 samples

### Review:
- [ ] Code approved by
- [ ] Tests executed by
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
