### PR TITLE
Prepare patch version 4.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change log
 
-## 
+## 4.9 (2022-01-20)
 ### Fixed
 - Typo in Makefile preventing loading of demodata
 - Multisample PDF reports

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ with codecs.open(os.path.join(HERE, "README.md"), encoding="utf-8") as f:
 setup(
     name="chanjo-report",
     # versions should comply with PEP440
-    version="4.9.0",
+    version="4.9.1",
     description="Automatically render coverage reports from Chanjo ouput",
     long_description=LONG_DESCRIPTION,
     # what does your project relate to?


### PR DESCRIPTION
## 4.9 (2022-01-20)
### Fixed
- Typo in Makefile preventing loading of demodata
- Multisample PDF reports

### Review:
- [ ] Code approved by
- [ ] Tests executed by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
