### PR TITLE
Avoid crash when user provides non-integer gene IDs in the report endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+##
+### Fixed
+- App crashing when unsupported gene IDs are provided in the report endpoint
+
 ## 4.9 (2022-01-20)
 ### Fixed
 - Typo in Makefile preventing loading of demodata

--- a/chanjo_report/server/blueprints/report/controllers.py
+++ b/chanjo_report/server/blueprints/report/controllers.py
@@ -17,31 +17,33 @@ def report_contents(request):
 
     sample_ids = request.args.getlist("sample_id") or request.form.getlist("sample_id")
     raw_gene_ids = request.args.get("gene_ids") or request.form.get("gene_ids")
-    gene_ids = []
     if raw_gene_ids:
         session["all_genes"] = raw_gene_ids
         gene_ids = [gene_id.strip() for gene_id in raw_gene_ids.split(",")]
     else:
         if request.method == "GET" and session.get("all_genes"):
             gene_ids = [gene_id.strip() for gene_id in session.get("all_genes").split(",")]
-    try:
-        # gene ids should be numerical, if they are strings print error String instead
-        gene_ids = [int(gene_id) for gene_id in gene_ids]
-    except ValueError:
-        return "Gene format not supported. Gene list should contain comma-separated HGNC numerical identifiers, not strings."
+
+    int_gene_ids = set()
+    gene_id_errors = set()
+    for gene_id in gene_ids:
+        try:
+            int_gene_ids.add(int(gene_id))
+        except ValueError:
+            gene_id_errors.add(gene_id)
 
     level = int(request.args.get("level") or request.form.get("level") or 10)
     extras = {
         "panel_name": (request.args.get("panel_name") or request.form.get("panel_name")),
         "level": level,
-        "gene_ids": gene_ids,
+        "gene_ids": list(int_gene_ids),
         "show_genes": any([request.args.get("show_genes"), request.form.get("show_genes")]),
     }
     samples = Sample.query.filter(Sample.id.in_(sample_ids))
     case_name = request.args.get("case_name") or request.form.get("case_name")
     sex_rows = samplesex_rows(sample_ids)
-    metrics_rows = keymetrics_rows(sample_ids, genes=gene_ids)
-    tx_rows = transcripts_rows(sample_ids, genes=gene_ids, level=level)
+    metrics_rows = keymetrics_rows(sample_ids, genes=int_gene_ids)
+    tx_rows = transcripts_rows(sample_ids, genes=int_gene_ids, level=level)
 
     data = dict(
         sample_ids=sample_ids,
@@ -52,5 +54,6 @@ def report_contents(request):
         extras=extras,
         metrics_rows=metrics_rows,
         tx_rows=tx_rows,
+        gene_id_errors=gene_id_errors,
     )
     return data

--- a/chanjo_report/server/blueprints/report/controllers.py
+++ b/chanjo_report/server/blueprints/report/controllers.py
@@ -17,6 +17,7 @@ def report_contents(request):
 
     sample_ids = request.args.getlist("sample_id") or request.form.getlist("sample_id")
     raw_gene_ids = request.args.get("gene_ids") or request.form.get("gene_ids")
+    gene_ids = []
     if raw_gene_ids:
         session["all_genes"] = raw_gene_ids
         gene_ids = [gene_id.strip() for gene_id in raw_gene_ids.split(",")]

--- a/chanjo_report/server/blueprints/report/controllers.py
+++ b/chanjo_report/server/blueprints/report/controllers.py
@@ -33,11 +33,13 @@ def report_contents(request):
         except ValueError:
             gene_id_errors.add(gene_id)
 
+    int_gene_ids = list(int_gene_ids)
+
     level = int(request.args.get("level") or request.form.get("level") or 10)
     extras = {
         "panel_name": (request.args.get("panel_name") or request.form.get("panel_name")),
         "level": level,
-        "gene_ids": list(int_gene_ids),
+        "gene_ids": int_gene_ids,
         "show_genes": any([request.args.get("show_genes"), request.form.get("show_genes")]),
     }
     samples = Sample.query.filter(Sample.id.in_(sample_ids))

--- a/chanjo_report/server/blueprints/report/templates/report/report.html
+++ b/chanjo_report/server/blueprints/report/templates/report/report.html
@@ -25,7 +25,7 @@
 		</div>
 
 		{% if gene_id_errors %}
-			<span style="background-color:#d9534f;color:white;">Gene list should contain comma-separated HGNC numerical identifiers, not strings. Unsopported gene identifiers: {{gene_id_errors}} were not taken into account.</span>
+			<span style="background-color:#d9534f;color:white;">Gene list should contain comma-separated HGNC numerical identifiers, not strings. Unsupported gene identifiers: {{gene_id_errors}} were not taken into account.</span>
 		{% endif %}
 
 		<h2>{{ _('Quality report') }}: {{ _('clinical sequencing') }}</h2>

--- a/chanjo_report/server/blueprints/report/templates/report/report.html
+++ b/chanjo_report/server/blueprints/report/templates/report/report.html
@@ -24,6 +24,10 @@
 			</div>
 		</div>
 
+		{% if gene_id_errors %}
+			<span style="background-color:#d9534f;color:white;">Gene list should contain comma-separated HGNC numerical identifiers, not strings. Unsopported gene identifiers: {{gene_id_errors}} were not taken into account.</span>
+		{% endif %}
+
 		<h2>{{ _('Quality report') }}: {{ _('clinical sequencing') }}</h2>
 		{% if extras.panel_name %}
 			<p>{{ _('Based on gene panel') }}: <strong>{{ extras.panel_name }}</strong></p>


### PR DESCRIPTION
### This PR adds | fixes:
- Fix #26 

**How to reproduce the bug**
- [x] Setup a demo db using the following command: `make setup`
- [x] Create a report with the command: `make report`
- [x] Go to the report page: http://localhost:5000/report?sample_id=sample1&sample_id=sample2&sample_id=sample3
- [x] Search for coverage in gene with ID that is not valid (non- numerical), for instance add this the link above `&gene_ids=gene1,gene2,etc`

### How to test:
- [x] Switch to this. branch and repeat the above (after removing the chanjo-report containers and dangling images)
- [x] The error above shouldn't occur, and a red error message should be printed on the report instead

### Review:
- [x] Code approved by DN
- [x] Tests executed by DN, CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
