### PR TITLE
Prepare patch version 4.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Change log
 
-##
+## 4.9.2 (2022-02-07)
 ### Fixed
 - App crashing when unsupported gene IDs are provided in the report endpoint
 
-## 4.9 (2022-01-20)
+## 4.9.1 (2022-01-20)
 ### Fixed
 - Typo in Makefile preventing loading of demodata
 - Multisample PDF reports

--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,10 @@
 """Based on https://github.com/pypa/sampleproject/blob/master/setup.py."""
 import codecs
 import os
-from setuptools import setup, find_packages
-from setuptools.command.test import test as TestCommand
 import sys
+
+from setuptools import find_packages, setup
+from setuptools.command.test import test as TestCommand
 
 # shortcut for building/publishing to Pypi
 if sys.argv[-1] == "publish":
@@ -47,7 +48,7 @@ with codecs.open(os.path.join(HERE, "README.md"), encoding="utf-8") as f:
 setup(
     name="chanjo-report",
     # versions should comply with PEP440
-    version="4.9.1",
+    version="4.9.2",
     description="Automatically render coverage reports from Chanjo ouput",
     long_description=LONG_DESCRIPTION,
     # what does your project relate to?


### PR DESCRIPTION
## 4.9.2 (2022-02-07)
### Fixed
- App crashing when unsupported gene IDs are provided in the report endpoint

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
