### PR TITLE
Fixed LocalStack.__ident_func__ missing error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change log
 
+## 4.9.3 (2022-04-26)
+### Changed
+- Install requirements from requirements file parsed in setup.py
+### Fixed
+- Error launching the app due to `LocalStack.__ident_func__` missing in werkzeug >= 2.1.x
+
 ## 4.9.2 (2022-02-07)
 ### Fixed
 - App crashing when unsupported gene IDs are provided in the report endpoint

--- a/chanjo_report/server/extensions.py
+++ b/chanjo_report/server/extensions.py
@@ -1,7 +1,7 @@
 from alchy import make_declarative_base, QueryModel, ManagerMixin
 from chanjo.store.models import BASE
 from flask_sqlalchemy import SQLAlchemy
-from greenlet import getcurrent as _get_ident
+from threading import get_ident
 
 
 class Alchy(SQLAlchemy, ManagerMixin):
@@ -14,7 +14,7 @@ class Alchy(SQLAlchemy, ManagerMixin):
             session_options = {}
 
         session_options.setdefault("query_cls", QueryModel)
-        session_options.setdefault("scopefunc", _get_ident)
+        session_options.setdefault("scopefunc", get_ident)
 
         self.Model = Model
         self.make_declarative_base(Model)

--- a/chanjo_report/server/extensions.py
+++ b/chanjo_report/server/extensions.py
@@ -5,7 +5,10 @@ from threading import get_ident
 
 
 class Alchy(SQLAlchemy, ManagerMixin):
-    """Flask extension that integrates alchy with Flask-SQLAlchemy."""
+    """Flask extension that integrates alchy with Flask-SQLAlchemy.
+    Originally developed in Flask-Alchy (https://github.com/dgilland/flask-alchy).
+    It has some changes here due to the deprecation in required libs (flask and flask_sqlalchemy)
+    """
 
     def __init__(
         self, app=None, use_native_unicode=True, session_options=None, Model=None, metadata=None

--- a/chanjo_report/server/extensions.py
+++ b/chanjo_report/server/extensions.py
@@ -7,7 +7,7 @@ from threading import get_ident
 class Alchy(SQLAlchemy, ManagerMixin):
     """Flask extension that integrates alchy with Flask-SQLAlchemy.
     Originally developed in Flask-Alchy (https://github.com/dgilland/flask-alchy).
-    It has some changes here due to the deprecation in required libs (flask and flask_sqlalchemy)
+    It has some changes here due to deprecated code in required libs (flask and flask_sqlalchemy)
     """
 
     def __init__(

--- a/chanjo_report/server/extensions.py
+++ b/chanjo_report/server/extensions.py
@@ -1,8 +1,31 @@
-# -*- coding: utf-8 -*-
-"""Extensions module. Each extension is initialized in the app factory
-located in app.py
-"""
+from alchy import make_declarative_base, QueryModel, ManagerMixin
 from chanjo.store.models import BASE
-from flask_alchy import Alchy
+from flask_sqlalchemy import SQLAlchemy
+from greenlet import getcurrent as _get_ident
+
+
+class Alchy(SQLAlchemy, ManagerMixin):
+    """Flask extension that integrates alchy with Flask-SQLAlchemy."""
+
+    def __init__(
+        self, app=None, use_native_unicode=True, session_options=None, Model=None, metadata=None
+    ):
+        if session_options is None:
+            session_options = {}
+
+        session_options.setdefault("query_cls", QueryModel)
+        session_options.setdefault("scopefunc", _get_ident)
+
+        self.Model = Model
+        self.make_declarative_base(Model)
+
+        super(Alchy, self).__init__(app, use_native_unicode, session_options, metadata=metadata)
+
+        self.Query = session_options["query_cls"]
+
+    def __getattr__(self, attr):
+        """Delegate all other attributes to self.session"""
+        return getattr(self.session, attr)
+
 
 api = Alchy(Model=BASE)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,3 @@
--r ../requirements.txt
-
 bumpversion
 coverage
 coveralls
@@ -8,5 +6,5 @@ invoke
 pytest
 sphinx
 sphinxcontrib-napoleon
-wheel>=0.23.0
+wheel
 Flask-Script

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,15 +1,20 @@
--r requirements/conda.txt
-
+alchy
+cairocffi
 chanjo>=4.1.0
-Flask-WeasyPrint
+cffi
+Flask
 Flask-Assets
 Flask-Babel
 Flask-DebugToolbar
-Flask-Alchy
+Flask-WeasyPrint
+greenlet
+lxml>=3.0
 path.py
+pymysql
 pyscss
-cairocffi
+six
+sqlservice
+Flask-SQLAlchemy
 tabulate
 toml
 toolz
-pymysql

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ Flask-Assets
 Flask-Babel
 Flask-DebugToolbar
 Flask-WeasyPrint
-greenlet
 lxml>=3.0
 path.py
 pymysql

--- a/requirements/conda.txt
+++ b/requirements/conda.txt
@@ -1,6 +1,0 @@
-# conda installables
-lxml>=3.0
-cffi
-Flask
-six
-SQLAlchemy

--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,32 @@
 # -*- coding: utf-8 -*-
 """Based on https://github.com/pypa/sampleproject/blob/master/setup.py."""
 import codecs
+import io
 import os
 import sys
 
 from setuptools import find_packages, setup
 from setuptools.command.test import test as TestCommand
+
+HERE = os.path.abspath(os.path.dirname(__file__))
+
+
+def parse_reqs(req_path="./requirements.txt"):
+    """Parse lib requirements from requirement.txt file"""
+    install_requires = []
+    with io.open(os.path.join(HERE, "requirements.txt"), encoding="utf-8") as handle:
+        # remove comments and empty lines
+        lines = (line.strip() for line in handle if line.strip() and not line.startswith("#"))
+
+        for line in lines:
+            # add the line as a new requirement
+            install_requires.append(line)
+
+    return install_requires
+
+
+REQUIRED = parse_reqs()
+
 
 # shortcut for building/publishing to Pypi
 if sys.argv[-1] == "publish":
@@ -40,7 +61,6 @@ class PyTest(TestCommand):
 
 
 # get the long description from the relevant file
-HERE = os.path.abspath(os.path.dirname(__file__))
 with codecs.open(os.path.join(HERE, "README.md"), encoding="utf-8") as f:
     LONG_DESCRIPTION = f.read()
 
@@ -72,21 +92,7 @@ setup(
         ]
     },
     zip_safe=False,
-    install_requires=[
-        "setuptools",
-        "chanjo>=4.1.0",
-        "Flask-WeasyPrint",
-        "cairocffi",
-        "lxml>=3.0",
-        "cffi",
-        "Flask",
-        "SQLAlchemy",
-        "Flask-Babel",
-        "tabulate",
-        "Flask-Alchy",
-        "Flask-SQLAlchemy==2.1",
-        "pymysql",
-    ],
+    install_requires=REQUIRED,
     tests_require=["pytest"],
     cmdclass={"test": PyTest},
     # to provide executable scripts, use entry points


### PR DESCRIPTION
### This PR adds | fixes:
- Simpler way of installing required libs
- Fix #31 by writing a custom Alchy class with the error fixed instead of importing and using the class from Flask-Alchy

**How to prepare for test**:
- Remove all chanjo and chanjo-report Docker images (run docker system prune after removing stuff from docker interface)

### How to test:
Run:
- `make setup`
- `make report`

### Expected outcome:
HTML report should show with no errors --> http://localhost:5000/report?sample_id=sample1&sample_id=sample2&sample_id=sample3

### Review:
- [ ] Code approved by
- [ ] Tests executed by
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
