### PR TITLE
Compress gene list in session and async report responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change log
 
 ## [Unreleased]
+### Changed
+- Modify `report` and `pdf` endpoints to return async responses
+- Compress list of genes saved in session object using numcompress (https://github.com/amit1rrr/numcompress) 
 ### Fixed
 - Use virtual environment and multi-stage build in Dockerfile
 - `Babel` object has no attribute `localeselector` error at startup

--- a/chanjo_report/server/blueprints/report/controllers.py
+++ b/chanjo_report/server/blueprints/report/controllers.py
@@ -1,6 +1,6 @@
 from chanjo.store.models import Sample
 from flask import session
-from numcompress import decompress
+from numcompress import compress, decompress
 
 from chanjo_report.server.constants import LEVELS
 
@@ -35,6 +35,7 @@ def report_contents(request):
                 gene_id_errors.add(gene_id)
 
         int_gene_ids = list(int_gene_ids)
+        session["all_genes"] = compress(int_gene_ids, precision=0)
     elif request.method == "GET" and session.get("all_genes"):
         int_gene_ids = decompress(session["all_genes"])
 

--- a/chanjo_report/server/blueprints/report/controllers.py
+++ b/chanjo_report/server/blueprints/report/controllers.py
@@ -22,10 +22,10 @@ def report_contents(request):
     raw_gene_ids = request.args.get("gene_ids") or request.form.get("gene_ids")
     compression = request.args.get("compression") or request.form.get("compression")
 
-    if raw_gene_ids and compression:  # ex: 'B_twxZnv_nB_bwm@'
+    if raw_gene_ids and compression:  # ex: '?qi]~wNq_c@'
         session["all_genes"] = raw_gene_ids
         int_gene_ids = decompress(raw_gene_ids)
-    elif raw_gene_ids:  # ex: 14578,12759,13525
+    elif raw_gene_ids:  # ex: '15529,7449,25890'
         int_gene_ids = set()
         gene_ids = [gene_id.strip() for gene_id in raw_gene_ids.split(",")]
         for gene_id in gene_ids:

--- a/chanjo_report/server/blueprints/report/views.py
+++ b/chanjo_report/server/blueprints/report/views.py
@@ -125,14 +125,14 @@ def json_gene_coverage():
 
 
 @report_bp.route("/report", methods=["GET", "POST"])
-def report():
+async def report():
     """Generate a coverage report for a group of samples."""
     data = controllers.report_contents(request)
     return render_template("report/report.html", **data)
 
 
 @report_bp.route("/report/pdf", methods=["GET", "POST"])
-def pdf():
+async def pdf():
     """Generate a PDF coverage report for a group of samples."""
     data = controllers.report_contents(request)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ Flask-Babel>=3
 Flask-DebugToolbar
 Flask-WeasyPrint
 lxml>=3.0
+numcompress
 path.py
 pymysql
 pyscss

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ alchy
 cairocffi
 chanjo>=4.1.0
 cffi
-Flask
+Flask[async]
 Flask-Assets
 Flask-Babel>=3
 Flask-DebugToolbar


### PR DESCRIPTION
### This PR adds | fixes:
- Compress long list of genes in session object using the [numcompress algorithm](https://github.com/amit1rrr/numcompress)

Example:
```
>>> from numcompress import compress, decompress
>>> gene_list = [15529,7449,25890]
>>> compressed = compress(gene_list, precision=0)
>>> compressed
'?qi]~wNq_c@'
>>> decompress(compressed)
[15529, 7449, 25890]
```
  
- Modified `report` and `pdf` endpoint to return async responses

### How to test:
- clone the repo and make sure you don't have any previous containers or images of it in Docker
Run:
- `make build` (builds the images)
- `make setup` (calls chanjo to populate demo data)
- `make report` (invokes chanjo report)
- Query demo server with a list of genes: http://localhost:5000/report?level=10&panel_name=&gene_ids=12506%2C+6834%2C+15529%2C+40020&show_genes=on&sample_id=sample1&sample_id=sample2&sample_id=sample3
- Query demo server with a compressed list of genes: http://localhost:5000/report?level=10&panel_name=&gene_ids=?slWnaJm~Ouyn@&compression=y&show_genes=on&sample_id=sample1&sample_id=sample2&sample_id=sample3

### Expected outcome:
- [x] The results should be the same

### Review:
- [ ] Code approved by
- [ ] Tests executed by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
