### PR TITLE
Release 4.9.4 - Babel fix, Docker envs and less explicit session storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change log
 
-## [Unreleased]
+## 4.9.4 (2023-03-06)
+### Changed
+- Remove one more use of GET and flask session storage to avoid overloading the session cookie
 ### Fixed
 - Use virtual environment and multi-stage build in Dockerfile
 - `Babel` object has no attribute `localeselector` error at startup

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ with codecs.open(os.path.join(HERE, "README.md"), encoding="utf-8") as f:
 setup(
     name="chanjo-report",
     # versions should comply with PEP440
-    version="4.9.3",
+    version="4.9.4",
     description="Automatically render coverage reports from Chanjo ouput",
     long_description=LONG_DESCRIPTION,
     # what does your project relate to?


### PR DESCRIPTION
I think we have to release as well to properly test this with Scout-stage. This is perhaps something to amend in the future, but we have tested this in isolation, so should be fine.