### PR TITLE
Docker docs, force AMD64. GitHub Action PyPi base image latest. Fix #42 and #45.

### DIFF
--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -8,7 +8,7 @@ on:
 jobs:
  build-n-publish:
   name: Build and publish Python distribution to PyPI
-  runs-on: ubuntu-18.04
+  runs-on: ubuntu-latest
   steps:
    - name: Check out git repository
      uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change log
 
+## Unreleased
+### Added
+- Documentation for Docker demo build
+### Fixed
+- Update from deprecated Ubuntu base image for the PyPi build publish flow
+
 ## 4.9.4 (2023-03-06)
 ### Changed
 - Remove one more use of GET and flask session storage to avoid overloading the session cookie

--- a/README.md
+++ b/README.md
@@ -42,20 +42,59 @@ $ cd chanjo-report
 $ pip install --editable .
 ```
 
-### Docker
+### Demo instance with Docker
 
-To run a local demo with Docker, ensure you have a local Docker running.
+To run a local demo with Docker, ensure you have a Docker engine running.
+If you do not have Docker set up, we can recommend Docker Desktop (https://www.docker.com/products/docker-desktop/).
+
+Then use `make` with the repository `Makefile` to build and run:
+
 ```bash
 make build
 make setup
 make report
 ```
-After that, you can interact with a local report in your browser on `http://127.0.0.1:5000`.
 
-If you do not have Docker set up, we can recommend Docker Desktop (https://www.docker.com/products/docker-desktop/).
-If you are on Apple silicon, we currently have good experience with forcing AMD64 before running your build:
-```bash
-export DOCKER_DEFAULT_PLATFORM=linux/amd64
+Point your browser to `http://127.0.0.1:5000` and find the demo samples.
+
+#### Comprehensive instructions
+
+We provide a Dockerfile to run the server in a container. To run a demo instance of the server with a pre-populated database consisting of a case with 3 samples, clone the repository using the following commands:
+
+ ```bash
+ $ git clone https://github.com/Clinical-Genomics/chanjo-report.git
+ $ cd chanjo-report
+ ```
+
+Then you could make use of the services present in the Docker-compose file following these 3 steps:
+
+1. Build the images
+
+    ```bash
+    make build
+    ```
+
+2. Launch chanjo to create a populate the database with demo data
+
+    ```bash
+    make setup
+    ```
+
+3. Launch the chanjo-report server
+
+     ```bash
+     make report
+     ```
+
+A running instance of the server should now be available at the following url: http://localhost:5000/.
+
+In order to generate a report containing all 3 demo samples, use the respective request args: http://localhost:5000/report?sample_id=sample1&sample_id=sample2&sample_id=sample3
+
+Please be aware that if you are building and running the Dockerized version of chanjo-report, there might be **issues on `macOS` if your processor is Apple silicon** (or another `ARM64` based architecture).
+In order to build the `chanjo-report` image in the `ARM64` architecture, you can set the environment variable `DOCKER_DEFAULT_PLATFORM`:
+
+ ```bash
+ export DOCKER_DEFAULT_PLATFORM=linux/amd64
 make build
 make setup
 make report

--- a/README.md
+++ b/README.md
@@ -42,6 +42,24 @@ $ cd chanjo-report
 $ pip install --editable .
 ```
 
+### Docker
+
+To run a local demo with Docker, ensure you have a local Docker running.
+```bash
+make build
+make setup
+make report
+```
+After that, you can interact with a local report in your browser on `http://127.0.0.1:5000`.
+
+If you do not have Docker set up, we can recommend Docker Desktop (https://www.docker.com/products/docker-desktop/).
+If you are on Apple silicon, we currently have good experience with forcing AMD64 before running your build:
+```bash
+export DOCKER_DEFAULT_PLATFORM=linux/amd64
+make build
+make setup
+make report
+```
 
 ## License
 MIT. See the [LICENSE](LICENSE) file for more details.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     mariadb:
       container_name: mariadb
       image: mariadb:latest
+      platform: linux/amd64
       restart: 'always'
       environment:
         - MYSQL_ROOT_PASSWORD=root
@@ -20,6 +21,7 @@ services:
         - chanjo-net
 
     chanjo-cli:
+      platform: linux/amd64
       container_name: chanjo-cli
       image: clinicalgenomics/chanjo
       depends_on:
@@ -29,6 +31,7 @@ services:
         - chanjo-net
 
     chanjo-report:
+      platform: linux/amd64
       container_name: chanjo-report
       build:
         context: .


### PR DESCRIPTION
### This PR adds | fixes:
- Fix https://github.com/Clinical-Genomics/chanjo-report/issues/42 and https://github.com/Clinical-Genomics/chanjo-report/issues/45.

**How to prepare for test**:
- [ ] `ssh` to ...
- [ ] Install on stage:
`bash servers/resources/SERVER.scilifelab.se/update-[THIS_TOOL]-stage.sh [THIS-BRANCH-NAME]`

### How to test:
- test building and running Docker demo, according to docs preferably
- release to test PyPi build

### Expected outcome:
- [x] `make report` should work out of the box on Apple silicon
<img width="680" alt="Screenshot 2023-03-06 at 15 14 26" src="https://user-images.githubusercontent.com/758570/223134534-6e3368c6-601d-4fa8-9741-91ed6b3a23c1.png">
- [ ] pypi build should work on GitHub actions post release



### Review:
- [ ] Code approved by
- [ ] Tests executed by
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
