### PR TITLE
Create new minor v.4.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change log
 
-## Unreleased
+## 4.10 (2023-03-07)
 ### Added
 - Documentation for Docker demo build
 ### Fixed

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ with codecs.open(os.path.join(HERE, "README.md"), encoding="utf-8") as f:
 setup(
     name="chanjo-report",
     # versions should comply with PEP440
-    version="4.9.4",
+    version="4.10",
     description="Automatically render coverage reports from Chanjo ouput",
     long_description=LONG_DESCRIPTION,
     # what does your project relate to?


### PR DESCRIPTION
## 4.10 (2023-03-07)
### Added
- Documentation for Docker demo build
### Fixed
- Update from deprecated Ubuntu base image for the PyPi build publish flow

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
