### PR TITLE
Patch actions and bump version

### DIFF
--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -34,7 +34,7 @@ jobs:
         bdist_wheel
 
    - name: Publish distribution 📦 to PyPI
-     uses: pypa/gh-action-pypi-publish@master
+     uses: pypa/gh-action-pypi-publish@main
      with:
        user: __token__
        password: ${{ secrets.pypi_password }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 4.10.1 (2023-03-10)
+### Fixed
+- Actions using the renamed main branch
+
 ## 4.10 (2023-03-07)
 ### Added
 - Documentation for Docker demo build

--- a/setup.py
+++ b/setup.py
@@ -68,9 +68,10 @@ with codecs.open(os.path.join(HERE, "README.md"), encoding="utf-8") as f:
 setup(
     name="chanjo-report",
     # versions should comply with PEP440
-    version="4.10",
+    version="4.10.1",
     description="Automatically render coverage reports from Chanjo ouput",
     long_description=LONG_DESCRIPTION,
+    long_description_content_type='text/markdown',
     # what does your project relate to?
     keywords="chanjo-report development",
     author="Robin Andeer",


### PR DESCRIPTION
Use main branch in GitHub Actions. Fix content type issue for PyPi push. And patch-bump version.