### PR TITLE
Force index use in slow query that results in report timeout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ coverage.xml
 dev/
 instance/
 .env
+.idea/
 
 # Rope
 .ropeproject

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 4.10.2 (2023-08-16)
+### Fixed
+- Timeout when creating report due to slow transcript_stat query
+
 ## 4.10.1 (2023-03-10)
 ### Fixed
 - Fix GitHub Actions PyPi automation 

--- a/chanjo_report/server/blueprints/report/utils.py
+++ b/chanjo_report/server/blueprints/report/utils.py
@@ -105,6 +105,7 @@ def keymetrics_rows(samples_ids, genes=None):
             func.avg(TranscriptStat.completeness_50).label('completeness_50'),
             func.avg(TranscriptStat.completeness_100).label('completeness_100'),
         )
+        .with_hint(TranscriptStat, 'USE INDEX _sample_transcript_uc')
         .filter(TranscriptStat.sample_id.in_(samples_ids))
         .group_by(TranscriptStat.sample_id)
     )

--- a/chanjo_report/server/blueprints/report/utils.py
+++ b/chanjo_report/server/blueprints/report/utils.py
@@ -105,7 +105,7 @@ def keymetrics_rows(samples_ids, genes=None):
             func.avg(TranscriptStat.completeness_50).label('completeness_50'),
             func.avg(TranscriptStat.completeness_100).label('completeness_100'),
         )
-        .with_hint(TranscriptStat, 'USE INDEX _sample_transcript_uc')
+        .with_hint(TranscriptStat, "USE INDEX (_sample_transcript_uc)")
         .filter(TranscriptStat.sample_id.in_(samples_ids))
         .group_by(TranscriptStat.sample_id)
     )


### PR DESCRIPTION
### This PR adds | fixes:
- Fix #52 

### How to test:
Test the fix indirectly by using scout only. I've created a scout branch containing the code to create a report with code taken from here. [This scout branch](https://github.com/Clinical-Genomics/scout/pull/4031) contains this fix
- Check the performance of retrieving the HPO coverage report from [this case](https://scout-stage.scilifelab.se/cust000/643594-300M) using 2 distinct scout branches:
- The branch corresponding to the last release (version_4.70)
- The branch with this fix (speedup_hpo_cov)

### Expected outcome:
- [ ] Using the speedup_hpo_cov the report should be created without timeout

### Review:
- [ ] Code approved by
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
