### PR TITLE
Force use of index in genes overview query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [unreleased]
 ### Changed
 - Removed alchy dependency
+### Fixed
+- Timeout when creating genes overview due to slow transcript_stat query
 
 ## 4.10.2 (2023-08-16)
 ### Fixed

--- a/chanjo_report/server/blueprints/report/views.py
+++ b/chanjo_report/server/blueprints/report/views.py
@@ -55,6 +55,7 @@ def genes():
     completeness_col = getattr(TranscriptStat, "completeness_{}".format(level))
     query = (
         api.session.query(TranscriptStat)
+        .with_hint(TranscriptStat, "USE INDEX (_sample_transcript_uc)")
         .join(TranscriptStat.transcript)
         .filter(completeness_col < 100)
         .order_by(completeness_col)


### PR DESCRIPTION
### This PR adds | fixes:
- Fix #60

### How to test:
- Modify [this branch in scout](chanjo_report_recent_libs) to install this branch of chanjo-report
- Go to the genes overview on this panel ->  https://scout-stage.scilifelab.se/panels/5ab40f47124f631fa1c1199b?case_id=magicaldog&institute_id=cust003#

### Expected outcome:
- [ ] Genes overview report should be quicker to load than when you use any other scout branch

### Review:
- [ ] Code approved by
- [ ] Tests executed by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
