### PR TITLE
Minor release 4.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change log
 
-## [unreleased]
+## 4.11 (2024-05-23)
 ### Changed
 - Removed alchy dependency
 ### Fixed

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ with codecs.open(os.path.join(HERE, "README.md"), encoding="utf-8") as f:
 setup(
     name="chanjo-report",
     # versions should comply with PEP440
-    version="4.10.2",
+    version="4.11",
     description="Automatically render coverage reports from Chanjo ouput",
     long_description=LONG_DESCRIPTION,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Doesn't have the config for bumpversion!

## 4.11 (2024-05-23)
### Changed
- Removed alchy dependency
### Fixed
- Timeout when creating genes overview due to slow transcript_stat query