### PR TITLE
Deprecate pkg resources and fix mariadb healthcheck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 4.11.2 (2024-11-28)
 ### Fixed
-- 
+- Deprecate pkg_resources
 
 ## 4.11.1 (2024-06-05)
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change log
 
 ## 4.11.2 (2024-11-10)
+### Changed
+- Updated Dockerfile to use Python 3.12
 ### Fixed
 - Deprecate pkg_resources
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Updated Dockerfile to use Python 3.12
 ### Fixed
 - Deprecate pkg_resources
+- Healthcheck of MariaDB container in docker-compose.yml
 
 ## 4.11.1 (2024-06-05)
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 4.11.2 (2024-11-28)
+### Fixed
+- 
+
 ## 4.11.1 (2024-06-05)
 ### Fixed
 - Added cryptography module among the dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change log
 
-## 4.11.2 (2024-11-28)
+## 4.11.2 (2024-11-10)
 ### Fixed
 - Deprecate pkg_resources
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ###########
 # BUILDER #
 ###########
-FROM clinicalgenomics/python3.8-venv:1.0 AS python-builder
+FROM clinicalgenomics/python3.12-venv AS python-builder
 
 ENV PATH="/venv/bin:$PATH"
 
@@ -14,10 +14,10 @@ RUN pip install --no-cache-dir -r requirements.txt
 #########
 # FINAL #
 #########
-FROM python:3.8-slim
+FROM python:3.12-slim-bookworm
 
 LABEL about.license="MIT License (MIT)"
-LABEL about.tags="chanjo-report,chanjo,bam,NGS,coverage,python,python3.8,flask"
+LABEL about.tags="chanjo-report,chanjo,bam,NGS,coverage,python,flask"
 LABEL about.home="https://github.com/Clinical-Genomics/chanjo-report"
 
 # Install required libs

--- a/Makefile
+++ b/Makefile
@@ -11,12 +11,12 @@ setup: ## Use Chanjo to set up a mysql database containing demo data
 	echo "Setup chanjo database"
 	docker-compose run chanjo-cli /bin/bash -c "chanjo -d mysql+pymysql://chanjoUser:chanjoPassword@mariadb/chanjo4_test init --auto demodata && chanjo --config demodata/chanjo.yaml link demodata/hgnc.grch37p13.exons.bed"
 	echo "Loading coverage from demo files"
-	docker-compose run chanjo-cli chanjo -d mysql+pymysql://chanjoUser:chanjoPassword@mariadb/chanjo4_test load -n sample1 --group-name test_group -g test_group chanjo/init/demo-files/sample1.coverage.bed
-	docker-compose run chanjo-cli chanjo -d mysql+pymysql://chanjoUser:chanjoPassword@mariadb/chanjo4_test load -n sample2 --group-name test_group -g test_group chanjo/init/demo-files/sample2.coverage.bed
-	docker-compose run chanjo-cli chanjo -d mysql+pymysql://chanjoUser:chanjoPassword@mariadb/chanjo4_test load -n sample3 --group-name test_group -g test_group chanjo/init/demo-files/sample3.coverage.bed
+	docker-compose run chanjo-cli chanjo --config demodata/chanjo.yaml load -n sample1 --group-name test_group -g test_group chanjo/init/demo-files/sample1.coverage.bed
+	docker-compose run chanjo-cli chanjo --config demodata/chanjo.yaml load -n sample2 --group-name test_group -g test_group chanjo/init/demo-files/sample2.coverage.bed
+	docker-compose run chanjo-cli chanjo --config demodata/chanjo.yaml load -n sample3 --group-name test_group -g test_group chanjo/init/demo-files/sample3.coverage.bed
 
 report: ## Create a coverage report in HTML format
-	docker-compose run -p 5000:5000 chanjo-report chanjo -d mysql+pymysql://chanjoUser:chanjoPassword@mariadb/chanjo4_test report --render html
+	docker-compose run -p 5000:5000 chanjo-report chanjo --config demodata/chanjo.yaml report --render html
 
 prune: ## Remove orphans and dangling images
 	docker-compose down --remove-orphans

--- a/Makefile
+++ b/Makefile
@@ -11,12 +11,12 @@ setup: ## Use Chanjo to set up a mysql database containing demo data
 	echo "Setup chanjo database"
 	docker-compose run chanjo-cli /bin/bash -c "chanjo -d mysql+pymysql://chanjoUser:chanjoPassword@mariadb/chanjo4_test init --auto demodata && chanjo --config demodata/chanjo.yaml link demodata/hgnc.grch37p13.exons.bed"
 	echo "Loading coverage from demo files"
-	docker-compose run chanjo-cli chanjo --config demodata/chanjo.yaml load -n sample1 --group-name test_group -g test_group chanjo/init/demo-files/sample1.coverage.bed
-	docker-compose run chanjo-cli chanjo --config demodata/chanjo.yaml load -n sample2 --group-name test_group -g test_group chanjo/init/demo-files/sample2.coverage.bed
-	docker-compose run chanjo-cli chanjo --config demodata/chanjo.yaml load -n sample3 --group-name test_group -g test_group chanjo/init/demo-files/sample3.coverage.bed
+	docker-compose run chanjo-cli chanjo -d mysql+pymysql://chanjoUser:chanjoPassword@mariadb/chanjo4_test load -n sample1 --group-name test_group -g test_group chanjo/init/demo-files/sample1.coverage.bed
+	docker-compose run chanjo-cli chanjo -d mysql+pymysql://chanjoUser:chanjoPassword@mariadb/chanjo4_test load -n sample2 --group-name test_group -g test_group chanjo/init/demo-files/sample2.coverage.bed
+	docker-compose run chanjo-cli chanjo -d mysql+pymysql://chanjoUser:chanjoPassword@mariadb/chanjo4_test load -n sample3 --group-name test_group -g test_group chanjo/init/demo-files/sample3.coverage.bed
 
 report: ## Create a coverage report in HTML format
-	docker-compose run -p 5000:5000 chanjo-report chanjo --config demodata/chanjo.yaml report --render html
+	docker-compose run -p 5000:5000 chanjo-report chanjo -d mysql+pymysql://chanjoUser:chanjoPassword@mariadb/chanjo4_test report --render html
 
 prune: ## Remove orphans and dangling images
 	docker-compose down --remove-orphans

--- a/chanjo_report/__init__.py
+++ b/chanjo_report/__init__.py
@@ -8,7 +8,7 @@ Chanjo Report automatically renders a coverage report from Chanjo ouput.
 :copyright: (c) 2014 by Robin Andeer
 :licence: MIT, see LICENCE for more details
 """
-from pkg_resources import get_distribution
+from importlib.metadata import version
 
 # generate your own AsciiArt at:
 # patorjk.com/software/taag/#f=Calvin%20S&t=Chanjo Report
@@ -22,7 +22,7 @@ __title__ = 'chanjo-report'
 __summary__ = 'Automatically renders coverage reports from Chanjo ouput.'
 __uri__ = 'https://github.com/robinandeer/chanjo-report'
 
-__version__ = get_distribution(__title__).version
+__version__ = version(__title__)
 
 __author__ = 'Robin Andeer'
 __email__ = 'robin.andeer@gmail.com'

--- a/chanjo_report/cli/utils.py
+++ b/chanjo_report/cli/utils.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """Utilities related to entry point interfaces loaded by the CLI."""
-from pkg_resources import iter_entry_points
+from importlib.metadata import entry_points
 
 
 def iter_interfaces(ep_key='chanjo_report.interfaces'):
@@ -12,8 +12,16 @@ def iter_interfaces(ep_key='chanjo_report.interfaces'):
     Yields:
         object: Entry point object
     """
-    for entry_point in iter_entry_points(ep_key):
-        yield entry_point
+    eps = entry_points()
+    # Adjust based on Python's version of importlib.metadata
+    if hasattr(eps, 'select'):
+        # Python >= 3.10
+        for entry_point in eps.select(group=ep_key):
+            yield entry_point
+    else:
+        # For Python < 3.10
+        for entry_point in eps.get(ep_key, []):
+            yield entry_point
 
 
 def list_interfaces():

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,10 +13,12 @@ services:
         - MYSQL_DATABASE=chanjo4_test
         - MYSQL_USER=chanjoUser
         - MYSQL_PASSWORD=chanjoPassword
-      healthcheck: # Wait for the service to be ready before accepting incoming connections
-        test: "mysql --user=chanjoUser --password=chanjoPassword --execute \"SHOW DATABASES;\""
-        timeout: 10s
-        retries: 20
+      healthcheck:
+          test: [ "CMD", "healthcheck.sh", "--connect", "--innodb_initialized" ]
+          start_period: 10s
+          interval: 10s
+          timeout: 5s
+          retries: 3
       networks:
         - chanjo-net
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 cairocffi
-chanjo>=4.7
+chanjo>=4.7.1
 cffi
 cryptography
 Flask

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ Flask-Assets
 Flask-Babel>=3
 Flask-DebugToolbar
 Flask-WeasyPrint
+importlib_resources
 lxml>=3.0
 path.py
 pymysql

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 cairocffi
-chanjo>=4.7.1
+chanjo>=4.7.2
 cffi
 cryptography
 Flask

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ with codecs.open(os.path.join(HERE, "README.md"), encoding="utf-8") as f:
 setup(
     name="chanjo-report",
     # versions should comply with PEP440
-    version="4.11.1",
+    version="4.11.2",
     description="Automatically render coverage reports from Chanjo ouput",
     long_description=LONG_DESCRIPTION,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
## Description
### Fixed
- Fix #58
- Fix #67 
 
## Review
- [x] Tests executed by CR
- [x] "Merge and deploy" approved by DN

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
