### PR TITLE
Fix #69 - attempt to drop Flask-Assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Change log
 
-## unreleased
+## 4.11.3 (2025-03-13)
 ### Fixed
-- Removed abandonware webassets via removal of unused Flask-Assets dependency 
+- Removed `webassets` via removal of unused Flask-Assets dependency
 
 ## 4.11.2 (2024-11-10)
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## unreleased
+### Fixed
+- Removed abandonware webassets via removal of unused Flask-Assets dependency 
+
 ## 4.11.2 (2024-11-10)
 ### Changed
 - Updated Dockerfile to use Python 3.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ chanjo>=4.7.2
 cffi
 cryptography
 Flask
-Flask-Assets
 Flask-Babel>=3
 Flask-DebugToolbar
 Flask-WeasyPrint

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ with codecs.open(os.path.join(HERE, "README.md"), encoding="utf-8") as f:
 setup(
     name="chanjo-report",
     # versions should comply with PEP440
-    version="4.11.2",
+    version="4.11.3",
     description="Automatically render coverage reports from Chanjo ouput",
     long_description=LONG_DESCRIPTION,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
## Description

### Fixed

- Fixed #69 

### How to test

- [x] Build a Scout CLI and web server with this branch - https://github.com/Clinical-Genomics/scout/pull/5312

### Expected test outcome


- [x] Ensure the warnings are gone
- [x] Ensure the functionality is otherwise nominal; no particular system expected to malfunction
- [x] Take a screenshot and attach or copy/paste the output.


Looks good on stage: 
```
[hiseq.clinical@cg-services-stage ~]$ systemctl --user start scout@chanjo_rep_no_webasset
```
![Screenshot 2025-03-13 at 09 18 28](https://github.com/user-attachments/assets/f94f35ea-a0d2-40ee-9ec0-c179f3d3eebe)


## Review

- [x] Tests executed by DN
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
