### PR TITLE
Fix #69 again - this time, bump python version in automation for pip

### DIFF
--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -11,12 +11,12 @@ jobs:
   runs-on: ubuntu-latest
   steps:
    - name: Check out git repository
-     uses: actions/checkout@v2
+     uses: actions/checkout@v4
 
-   - name: Set up Python 3.7
-     uses: actions/setup-python@v2
+   - name: Set up Python 3.12
+     uses: actions/setup-python@v5
      with:
-      python-version: 3.7
+      python-version: 3.12
 
    - name: Install build tools
      run: >-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 4.11.4 (2025-08-13)
+### Fixed
+- Update automation with newer images to allow e.g. pip deployment
+
 ## 4.11.3 (2025-03-13)
 ### Fixed
 - Removed `webassets` via removal of unused Flask-Assets dependency

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ with codecs.open(os.path.join(HERE, "README.md"), encoding="utf-8") as f:
 setup(
     name="chanjo-report",
     # versions should comply with PEP440
-    version="4.11.3",
+    version="4.11.4",
     description="Automatically render coverage reports from Chanjo ouput",
     long_description=LONG_DESCRIPTION,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
## Description

### Fixed

- Update automation with newer images to allow e.g. PyPi deployment

### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_[TOOL]-t [TOOL] -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Release and see that the automation worked. Rinse and repeat. 

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
