### PR TITLE
With setuptools and 3.10

### DIFF
--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -13,15 +13,16 @@ jobs:
    - name: Check out git repository
      uses: actions/checkout@v4
 
-   - name: Set up Python 3.12
+   - name: Set up Python 3.9
      uses: actions/setup-python@v5
      with:
-      python-version: 3.12
+      python-version: 3.9
 
    - name: Install build tools
      run: >-
         python -m
         pip install
+        setuptools
         wheel
         twine
         --user

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Change log
 
+## 4.11.5 (2025-08-13)
+### Fixed
+- Update automation with slightly older python, and explicit setuptools
+
 ## 4.11.4 (2025-08-13)
 ### Fixed
-- Update automation with newer images to allow e.g. pip deployment
+- Update automation with newer images to allow e.g. pypi deployment
 
 ## 4.11.3 (2025-03-13)
 ### Fixed


### PR DESCRIPTION
## Description

### Fixed

- Update automation with slightly older python, and explicit setuptools


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_[TOOL]-t [TOOL] -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
