### PR TITLE
Fix v4.11.5

### DIFF
--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -13,10 +13,10 @@ jobs:
    - name: Check out git repository
      uses: actions/checkout@v4
 
-   - name: Set up Python 3.9
+   - name: Set up Python 3.10
      uses: actions/setup-python@v5
      with:
-      python-version: 3.9
+      python-version: 3.10
 
    - name: Install build tools
      run: >-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 ### Fixed
 - Update automation with slightly older python, and explicit setuptools
 
+## 4.11.5 (2025-08-13)
+### Fixed
+- Update automation with slightly older python (3.10), and explicit setuptools
+- Bump version and fix changelog
+
 ## 4.11.4 (2025-08-13)
 ### Fixed
 - Update automation with newer images to allow e.g. pypi deployment

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ with codecs.open(os.path.join(HERE, "README.md"), encoding="utf-8") as f:
 setup(
     name="chanjo-report",
     # versions should comply with PEP440
-    version="4.11.4",
+    version="4.11.5",
     description="Automatically render coverage reports from Chanjo ouput",
     long_description=LONG_DESCRIPTION,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
## Description

### Fixed
- Update automation with slightly older python (3.10), and explicit setuptools
- Bump version and fix changelog


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_[TOOL]-t [TOOL] -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
