### PR TITLE
Fix broken chanjo report --render pdf command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [unreleased]
 ### Changed
 - Replaced Flask-weasyprint (cairo and pango-based) with pdfkit (#79)
+### Fixed
+- `chanjo report --render pdf` command, Now accepting a list of samples and output file (#80)
 
 ## 4.11.5 (2025-08-13)
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 ### Changed
 - Replaced Flask-weasyprint (cairo and pango-based) with pdfkit (#79)
 ### Fixed
-- `chanjo report --render pdf` command, Now accepting a list of samples and output file (#80)
+- `chanjo report --render pdf` command now accepting a list of samples and output file (#80)
 
 ## 4.11.5 (2025-08-13)
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Change log
 
 ## [unreleased]
+### Added
+- Enable PEP 660–compatible editable installs (`pip install -e`) (#81)
 ### Changed
 - Replaced Flask-weasyprint (cairo and pango-based) with pdfkit (#79)
+- Removed `https://bootswatch.com/simplex/bootstrap.min.css` lib import from two base layouts since it's no longer available (#83)
 ### Fixed
 - Healthcheck in Docker demo setup (#77)
 - `chanjo report --render pdf` command now accepting a list of samples and output file (#80)

--- a/chanjo_report/cli/core.py
+++ b/chanjo_report/cli/core.py
@@ -6,10 +6,12 @@ from chanjo_report.interfaces import html, pdf
 
 @click.command()
 @click.option('-r', '--render', type=click.Choice(['html', 'pdf']), default='html')
+@click.option('-s', '--sample', 'samples', type=str, multiple=True, help='One or more sample names or IDs - Only for PDF reports')
+@click.option('-o', '--outfile', 'outfile', type=str, help='Outfile path - Only for PDF reports')
 @click.option('-l', '--language', type=click.Choice(['en', 'sv']))
 @click.option('-d', '--debug', is_flag=True)
 @click.pass_context
-def report(context, render, language, debug):
+def report(context, render, samples, outfile, language, debug):
     """Generate a coverage report from Chanjo SQL output."""
     # get uri + dialect of Chanjo database
     if context.obj['database'] is None:
@@ -17,9 +19,11 @@ def report(context, render, language, debug):
         context.abort()
 
     # set the custom option
-    context.obj['report'] = dict(language=language, debug=debug)
+    context.obj['report'] = dict(language=language, debug=debug, samples=samples, outfile=outfile)
 
     if render == 'html':
         html.render_html(context.obj)
     else:
+        if not samples:
+            raise ValueError("At least one sample is required to create a PDF report.")
         pdf.render_pdf(context.obj)


### PR DESCRIPTION
## Description
### Fixed
- Fix #36

Provide a CLI that accepts a list of samples and prints the PDF report where you want.

Given a database with 3 demo samples: sample1, sample2, sample3

### Before

<img width="971" height="355" alt="image" src="https://github.com/user-attachments/assets/7eded781-cc81-4440-820b-50e88fb5f898" />


### After

`chanjo -d mysql+pymysql://root:chiara78@localhost/chanjo4_test report --render pdf -s sample1 -s sample2 -s sample3 -o /Users/chiararasi/Desktop/appo.pdf`

<img width="944" height="717" alt="image" src="https://github.com/user-attachments/assets/ef2e4173-a7cf-44a0-bb42-3da391a85c30" />


## Review

- [x] Tests executed by CR
- [x] "Merge and deploy" approved by DN
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
