### PR TITLE
Enable PEP 660–compatible editable installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## [unreleased]
+### Added
+- Enable PEP 660–compatible editable installs (`pip install -e`) (#81)
+
 ## 4.11.5 (2025-08-13)
 ### Fixed
 - Update automation with slightly older python, and explicit setuptools

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools >= 64"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
## Description
### Added
- a `pyproject.toml` file, to enable editable installs without raising the setup.py deprecation warning
- Fix #78 

### Before

<img width="1208" height="324" alt="image" src="https://github.com/user-attachments/assets/025af738-00ae-4b2a-ad65-b50c597a095e" />


### After

<img width="1208" height="393" alt="image" src="https://github.com/user-attachments/assets/f5b28234-27db-4eb5-b782-cf2bafa349cc" />



## Review

- [x] Tests executed by CR
- [x] "Merge and deploy" approved by DN
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
