### PR TITLE
Remove css style that is no longer available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [unreleased]
 ### Changed
 - Replaced Flask-weasyprint (cairo and pango-based) with pdfkit (#79)
+- Removed `https://bootswatch.com/simplex/bootstrap.min.css` lib import from two base layouts since it's no longer available
 
 ## 4.11.5 (2025-08-13)
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [unreleased]
 ### Changed
 - Replaced Flask-weasyprint (cairo and pango-based) with pdfkit (#79)
-- Removed `https://bootswatch.com/simplex/bootstrap.min.css` lib import from two base layouts since it's no longer available
+- Removed `https://bootswatch.com/simplex/bootstrap.min.css` lib import from two base layouts since it's no longer available (#83)
 ### Fixed
 - Healthcheck in Docker demo setup (#77)
 

--- a/chanjo_report/server/blueprints/index/templates/index/layouts/base.html
+++ b/chanjo_report/server/blueprints/index/templates/index/layouts/base.html
@@ -18,9 +18,6 @@
 		<!-- Latest compiled and minified CSS -->
 		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
 
-		<!-- Optional theme -->
-		<link rel="stylesheet" href="https://bootswatch.com/simplex/bootstrap.min.css">
-
 		<!-- Customizations -->
 		<link rel="stylesheet" type="text/css" href="{{ url_for('report.static', filename='main.css') }}">
 	{% endblock %}

--- a/chanjo_report/server/blueprints/report/templates/report/layouts/base.html
+++ b/chanjo_report/server/blueprints/report/templates/report/layouts/base.html
@@ -18,9 +18,6 @@
 		<!-- Latest compiled and minified CSS -->
 		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
 
-		<!-- Optional theme -->
-		<link rel="stylesheet" href="https://bootswatch.com/simplex/bootstrap.min.css">
-
 		<!-- Customizations -->
 		<link rel="stylesheet" type="text/css" href="{{ url_for('report.static', filename='main.css') }}">
 	{% endblock %}


### PR DESCRIPTION
## Description
### Fixed
- Closes #82 - Tested locally and doesn't seem like those lib were used in the first place? 
- Style looks the same and I don't see any js errors in background


### Test

- [x] locally: `chanjo -d mysql+pymysql://root:chiara78@localhost/chanjo4_test report --render html`
- [x] Style looks OK with no js errors:

<img width="1596" height="901" alt="image" src="https://github.com/user-attachments/assets/3a6411dc-5155-49f1-b3a1-ac30f03ed48e" />


## Review

- [x] Tests executed by CR
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
