### PR TITLE
Release version 4.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change log
 
-## [unreleased]
+## 4.12.0 (2025-10-29) 
 ### Added
 - Enable PEP 660–compatible editable installs (`pip install -e`) (#81)
 ### Changed

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ with codecs.open(os.path.join(HERE, "README.md"), encoding="utf-8") as f:
 setup(
     name="chanjo-report",
     # versions should comply with PEP440
-    version="4.11.5",
+    version="4.12.0",
     description="Automatically render coverage reports from Chanjo ouput",
     long_description=LONG_DESCRIPTION,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
## 4.12.0 (2025-10-29) 
### Added
- Enable PEP 660–compatible editable installs (`pip install -e`) (#81)
### Changed
- Replaced Flask-weasyprint (cairo and pango-based) with pdfkit (#79)
- Removed `https://bootswatch.com/simplex/bootstrap.min.css` lib import from two base layouts since it's no longer available (#83)
### Fixed
- Healthcheck in Docker demo setup (#77)
- `chanjo report --render pdf` command now accepting a list of samples and output file (#80)

## Review

- [x] Tests executed by CR
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
